### PR TITLE
more cleanup as suggested in #165

### DIFF
--- a/_episodes_rmd/01-raster-structure.Rmd
+++ b/_episodes_rmd/01-raster-structure.Rmd
@@ -77,6 +77,7 @@ To open rasters in `R`, we will use the `raster` and `rgdal` packages.
 library(raster)
 library(rgdal)
 library(ggplot2)
+library(tidyr)
 ```
 
 ## Open a Raster in R
@@ -90,23 +91,33 @@ We can use the `raster("path-to-raster-here")` function to open a raster in R.
 {: .callout}
 
 
-```{r open-raster-ggplot, fig.width= 7, fig.height=7}
+```{r}
 # Load raster into R
 DSM_HARV <- raster("data/NEON-DS-Airborne-Remote-Sensing/HARV/DSM/HARV_dsmCrop.tif")
 
 # View raster structure
 DSM_HARV
+```
 
+> ## Exercise
+>
+> Insert exercise about looking at and explaining output above.
+{: .challenge}
+
+```{r}
 # convert to a df for plotting in two steps,
 # First, to a SpatialPointsDataFrame
-DSM_HARV_pts <- rasterToPoints(DSM_HARV, spatial = TRUE)
+DSM_HARV_df <- rasterToPoints(DSM_HARV, spatial = TRUE) %>%
 # Then to a 'conventional' dataframe
-DSM_HARV_df  <- data.frame(DSM_HARV_pts)
-rm(DSM_HARV_pts)
+    data.frame()
 
+# View dataframe structure
+str(DSM_HARV_df)
+```
+
+```{r, fig.width= 7, fig.height=7}
 ggplot() +
-    geom_raster(data = DSM_HARV_df , aes(x = x, y = y, fill = HARV_dsmCrop)) + 
-    ggtitle("Continuous Elevation Map - NEON Harvard Forest Field Site") + 
+    geom_raster(data = DSM_HARV_df , aes(x = x, y = y, fill = HARV_dsmCrop)) +
     coord_equal()
 
 ```
@@ -115,48 +126,9 @@ Here is a map showing the elevation of our site in Harvard Forest. Is the max
 elevation value within this raster greater than 400 meters or 400 feet? Perhaps
 we need to learn more about the data attributes from the metadata!
 
-## Coordinate Reference System
-The Coordinate Reference System or `CRS` tells `R` where the raster is located
-in geographic space. It also tells `R` what method should be used to "flatten"
-or project the raster in geographic space.
-
-<figure>
-    <a href="https://media.opennews.org/cache/06/37/0637aa2541b31f526ad44f7cb2db7b6c.jpg">
-    <img src="https://media.opennews.org/cache/06/37/0637aa2541b31f526ad44f7cb2db7b6c.jpg">
-    </a>
-
-    <figcaption> Maps of the United States in different projections. Notice the
-    differences in shape associated with each different projection. These
-    differences are a direct result of the calculations used to "flatten" the
-    data onto a 2-dimensional map. Source: opennews.org</figcaption>
-</figure>
-
-### What Makes Spatial Data Line Up On A Map?
-There are lots of great resources that describe coordinate reference systems and
-projections in greater detail (read more, below). For the purposes of this
-activity, what is important to understand is that data from the same location
-but saved in **different projections will not line up in any GIS or other
-program**. Thus, it's important when working with spatial data in a program like
-`R` to identify the coordinate reference system applied to the data and retain
-it throughout data processing and analysis.
-
-Read More:
-
-* <a href="http://spatialreference.org/ref/epsg/" target="_blank"> A comprehensive online library of CRS information.</a>
-* <a href="https://docs.qgis.org/2.18/en/docs/gentle_gis_introduction/coordinate_reference_systems.html" target="_blank">QGIS Documentation - CRS Overview.</a>
-* <a href="https://source.opennews.org/en-US/learning/choosing-right-map-projection/" target="_blank">Choosing the Right Map Projection.</a>
-* <a href="https://www.nceas.ucsb.edu/~frazier/RSpatialGuides/OverviewCoordinateReferenceSystems.pdf" target="_blank"> NCEAS Overview of CRS in R.</a>
-
-### How Map Projections Can Fool the Eye
-Check out this short video highlighting how map projections can make continents
-seems proportionally larger or smaller than they actually are!
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/KUF_Ckv8HbE" frameborder="0" allowfullscreen></iframe>
-
-
 ### View Raster Coordinate Reference System (CRS) in R
 We can view the `CRS` string associated with our `R` object using the`crs()`
-method. We can assign this string to an `R` object, too.
+function. We can assign this string to an `R` object, too.
 
 ```{r view-resolution-units}
 # view resolution units
@@ -195,42 +167,6 @@ projection. Our raster uses the `WGS84` datum.
 * `+units=m` This is the horizontal units that the data are in. Our units
 are meters.
 
-## Extent
-The spatial extent is the geographic area that the raster data covers.
-
-<figure>
-    <a href="../images/dc-spatial-raster/spatial_extent.png">
-    <img src="../images/dc-spatial-raster/spatial_extent.png">
-    </a>
-    <figcaption> Image Source: National Ecological Observatory Network (NEON)
-    </figcaption>
-</figure>
-
-The spatial extent of an R spatial object represents the geographic "edge" or
-location that is the furthest north, south, east and west. In other words, `extent`
-represents the overall geographic coverage of the spatial object.
-
-## Resolution
-A raster has horizontal (x and y) resolution. This resolution represents the
-area on the ground that each pixel covers. The units for our data are in meters.
-Given our data resolution is 1 x 1, this means that each pixel represents a
-1 x 1 meter area on the ground.
-
-<figure>
-    <a href="../images/dc-spatial-raster/raster_resolution.png">
-    <img src="../images/dc-spatial-raster/raster_resolution.png">
-    </a>
-    <figcaption> Source: National Ecological Observatory Network (NEON)
-    </figcaption>
-</figure>
-
-The best way to view resolution units is to look at the
-coordinate reference system string `crs()`. Notice our data contains: `+units=m`.
-
-``` {r resolution-units}
-crs(DSM_HARV)
-```
-
 ## Calculate Raster Min and Max Values
 
 It is useful to know the minimum or maximum values of a raster dataset. In
@@ -261,8 +197,8 @@ We can see that the elevation at our site ranges from 305.07m to 416.07m.
 Raster data often has a `NoDataValue` associated with it. This is a value
 assigned to pixels where data is missing or no data were collected.
 
-By default the shape of a raster is always square or rectangular. So if we
-have  a dataset that has a shape that isn't square or rectangular, some pixels
+By default the shape of a raster is always rectangular. So if we
+have  a dataset that has a shape that isn't rectangular, some pixels
 at the edge of the raster will have `NoDataValue`s. This often happens when the
 data were collected by an airplane which only flew over some part of a defined
 region.
@@ -287,8 +223,7 @@ rm(RGB_pts)
 
 ggplot() +
  geom_raster(data = RGB_df , aes(x = x, y = y, fill = HARV_RGB_Ortho.1),
-             show.legend = FALSE) + 
-    ggtitle("Raster with NoData Values Rendered in Black")
+             show.legend = FALSE)
 
 # more memory saving
 rm(RGB_df)
@@ -313,8 +248,7 @@ rm(newRGB_pts)
 
 ggplot() +
     geom_raster(data = newRGB_df , aes(x = x, y = y, fill = HARV_RGB_Ortho.1), 
-             show.legend = FALSE) + 
-    ggtitle("Raster with NoData Values labelled as NA")
+             show.legend = FALSE)
 #memory saving
 rm(newRGB_df)
 ```
@@ -362,9 +296,7 @@ identifying outliers and bad data values in our raster data.
 ```{r view-raster-histogram }
 
 ggplot() +
-    geom_histogram(data = DSM_HARV_df, aes(HARV_dsmCrop)) +
-    xlab("DSM Elevation Value (m)") +
-    ggtitle("Distribution of DSM Values in NEON Harvard Forest Field Site")
+    geom_histogram(data = DSM_HARV_df, aes(HARV_dsmCrop))
 
 ```
 
@@ -380,9 +312,7 @@ We can define the number of bins we want in the histogram by using the `bins` va
 ``` {r view-raster-histogram2}
 
 ggplot() +
-    geom_histogram(data = DSM_HARV_df, aes(HARV_dsmCrop), bins = 40) +
-    xlab("DSM Elevation Value (m)") +
-    ggtitle("Distribution of DSM Values in NEON Harvard Forest Field Site")
+    geom_histogram(data = DSM_HARV_df, aes(HARV_dsmCrop), bins = 40)
 
 ```
 

--- a/_episodes_rmd/01-raster-structure.Rmd
+++ b/_episodes_rmd/01-raster-structure.Rmd
@@ -72,10 +72,12 @@ elements. Finally, it introduces the GeoTiff file format.
 Let's first import a raster dataset into `R` and explore its metadata.
 To open rasters in `R`, we will use the `raster` and `rgdal` packages.
 
-```{r load-libraries }
-# load libraries
+```{r load-libraries}
 library(raster)
 library(rgdal)
+```
+
+```{r load-more-libraries echo=FALSE}
 library(ggplot2)
 library(tidyr)
 ```


### PR DESCRIPTION
Implements the following items from https://github.com/datacarpentry/r-raster-vector-geospatial/issues/165.

- [ ] Break the code block that starts "convert to a df for plotting in two steps," into two chunks, first for the DTM conversion, second for the plotting. Have learners check the structure of the DTM before plotting (good point for exercise). 
- [ ] Use pipes instead of creating intermediate object (`DSM_HARV_pts`). Learners will have used pipes in a previous lesson. This will cut down two lines of code (no longer need the `rm()` call). 
- [ ] Remove `ggtitle()` call in first `ggplot()` call to cut down on typing.(?)
- [ ] "crs() method" should be "crs() function"
- [ ] simplify "square of rectangular" to "rectangular"
- [ ] remove "xlab" and "ggtitle" calls in ggplot calls (multiple) to minimize typing. (?)