### PR TITLE
Implement suggestions from #165

### DIFF
--- a/_episodes_rmd/02-raster-plot.Rmd
+++ b/_episodes_rmd/02-raster-plot.Rmd
@@ -34,48 +34,14 @@ source("../setup.R")
 knitr_fig_path("02-")
 ```
 
-This tutorial reviews how to plot a raster in `R` using the `plot()`
-function. It also covers how to layer a raster on top of a hillshade to produce
+This episode covers how to plot a raster in `R` using the `ggplot2`
+package. It also covers how to layer a raster on top of a hillshade to produce
 an eloquent map.
 
 ## Plot Raster Data in R
-In this tutorial, we will plot the Digital Surface Model (DSM) raster
+In this episode, we will plot the Digital Surface Model (DSM) raster
 for the NEON Harvard Forest Field Site. We will use the `hist()` function as a
-tool to explore raster values. And render categorical plots, using the `breaks` argument to get bins that are meaningful representations of our data.
-
-We will use the `raster` and `rgdal` packages in this tutorial. If you do not
-have the `DSM_HARV` object from the
-[Intro To Raster In R tutorial]({{ site.baseurl }}/R/Introduction-to-Raster-Data-In-R/),
-please create it now.
-
-```{r load-libraries }
-# if they are not already loaded
-library(rgdal)
-library(raster)
-
-# import raster
-DSM_HARV <- raster("data/NEON-DS-Airborne-Remote-Sensing/HARV/DSM/HARV_dsmCrop.tif")
-
-```
-
-First, let's plot our Digital Surface Model object (`DSM_HARV`) using the
-`plot()` function. We add a title using the argument `main = "title"`.
-
-```{r ggplot-raster, fig.width= 7, fig.height=7 }
-library(ggplot2)
-
-# convert to a df for plotting in two steps,
-# First, to a SpatialPointsDataFrame
-DSM_HARV_pts <- rasterToPoints(DSM_HARV, spatial = TRUE)
-# Then to a 'conventional' dataframe
-DSM_HARV_df  <- data.frame(DSM_HARV_pts)
-rm(DSM_HARV_pts, DSM_HARV)
-
-ggplot() +
- geom_raster(data = DSM_HARV_df , aes(x = x, y = y, fill = HARV_dsmCrop)) + 
-    ggtitle("Continuous Elevation Map - NEON Harvard Forest Field Site")
-
-```
+tool to explore raster values and render categorical plots, using the `breaks` argument to get bins that are meaningful representations of our data.
 
 ## Plotting Data Using Breaks
 We can view our data "symbolized" or colored according to ranges of values
@@ -84,7 +50,6 @@ map. However, to assign breaks, it is useful to first explore the distribution
 of the data using a bar plot. 
 We use `dplyr`'s mutate to combined with `cut()` to split the data into 3 bins.
 
-
 ```{r histogram-breaks-ggplot, fig.width= 7, fig.height=7}
 library(dplyr)
 
@@ -92,9 +57,7 @@ DSM_HARV_df <- DSM_HARV_df %>%
                 mutate(fct_elevation = cut(HARV_dsmCrop, breaks = 3))
 
 ggplot() +
-    geom_bar(data = DSM_HARV_df, aes(fct_elevation)) +
-    xlab("Elevation (m)") +
-    ggtitle("Histogram Digital Surface Model - NEON Harvard Forest Field Site")
+    geom_bar(data = DSM_HARV_df, aes(fct_elevation))
 
 ```
 
@@ -130,17 +93,17 @@ unique(DSM_HARV_df$fct_elevation_2)
 
 ```
 
-> ## Data Tip
+> ## Data Tips
 > Note that when we assign break values a set of 4 values will result in 3 bins of data.
+>
+> The bin intervals are shown using `(` to mean inclusive and `]` to mean exclusive. For example: `(305, 342]` means "from 305 through 341".
 {: .callout}
 
 And now we can plot our bar plot again, using the new bins:
 
 ```{r, fig.width= 7, fig.height=7 }
 ggplot() +
-    geom_bar(data = DSM_HARV_df, aes(fct_elevation_2)) +
-    xlab("Elevation (m)") +
-    ggtitle("Histogram Digital Surface Model - NEON Harvard Forest Field Site \nCustom Bin Ranges")
+    geom_bar(data = DSM_HARV_df, aes(fct_elevation_2))
 ```
 
 We can also look at the how frequent each occurence of our bins is:
@@ -159,8 +122,7 @@ We can use those bins to plot our raster data:
 ```{r ggplot-with-breaks, fig.width= 7, fig.height=7}
 
 ggplot() +
- geom_raster(data = DSM_HARV_df , aes(x = x, y = y, fill = fct_elevation_2)) + 
-    ggtitle("Classified Elevation Map - NEON Harvard Forest Field Site")
+ geom_raster(data = DSM_HARV_df , aes(x = x, y = y, fill = fct_elevation_2))
 ```
 
 
@@ -184,8 +146,7 @@ To use these in our map, we pass them across using the
 ggplot() +
  geom_raster(data = DSM_HARV_df , aes(x = x, y = y,
                                       fill = fct_elevation_2)) + 
-    scale_fill_manual(values = terrain.colors(3)) + 
-    ggtitle("Classified Elevation Map - NEON Harvard Forest Field Site")
+    scale_fill_manual(values = terrain.colors(3))
 ```
 
 
@@ -207,10 +168,7 @@ my_col <- terrain.colors(3)
 ggplot() +
  geom_raster(data = DSM_HARV_df , aes(x = x, y = y,
                                       fill = fct_elevation_2)) + 
-    scale_fill_manual(values = my_col, name = "Elevation") + 
-    ggtitle("Classified Elevation Map - NEON Harvard Forest Field Site") +
-    xlab("UTM Westing Coordinate (m)") +
-    ylab("UTM Northing Coordinate (m)")
+    scale_fill_manual(values = my_col, name = "Elevation")
 ```
 
 Or we can also turn off the axes altogether via passing `element_blank()` to
@@ -221,8 +179,7 @@ the relevant parts of the `theme()` function.
 ggplot() +
  geom_raster(data = DSM_HARV_df , aes(x = x, y = y,
                                       fill = fct_elevation_2)) + 
-    scale_fill_manual(values = my_col, name = "Elevation") + 
-    ggtitle("Classified Elevation Map - NEON Harvard Forest Field Site") +
+    scale_fill_manual(values = my_col, name = "Elevation") +
     theme(axis.title.x = element_blank(),
           axis.title.y = element_blank())
 ```
@@ -263,25 +220,30 @@ hillshade is a raster that maps the shadows and texture that you would see from
 above when viewing terrain.
 We will add a custom color, making the plot grey. 
 
-```{r hillshade, fig.width= 7, fig.height=7}
+```{r}
 # import DSM hillshade
 DSM_hill_HARV <-
   raster("data/NEON-DS-Airborne-Remote-Sensing/HARV/DSM/HARV_DSMhill.tif")
 
+# View data structure
+DSM_hill_HARV
+```
+
+```{r}
 # convert to a df for plotting in two steps,
 # First, to a SpatialPointsDataFrame
-DSM_hill_HARV_pts <- rasterToPoints(DSM_hill_HARV, spatial = TRUE)
+DSM_hill_HARV_df <- rasterToPoints(DSM_hill_HARV, spatial = TRUE) %>%
 # Then to a 'conventional' dataframe
-DSM_hill_HARV_df  <- data.frame(DSM_hill_HARV_pts)
-rm(DSM_hill_HARV_pts, DSM_hill_HARV)
+    data.frame()
 
+# View data structure
+str(DSM_hill_HARV_df)
+```
+
+```{r, fig.width= 7, fig.height=7}
 ggplot() +
  geom_raster(data = DSM_hill_HARV_df , aes(x = x, y = y, alpha = HARV_DSMhill)) + 
-    scale_alpha(range =  c(0.15, 0.65), guide = "none") +
-    ggtitle("Hillshade - DSM - NEON Harvard Forest Field Site") +
-    theme(axis.title.x = element_blank(),
-          axis.title.y = element_blank())
-
+    scale_alpha(range =  c(0.15, 0.65), guide = "none")
 ```
 
 
@@ -308,9 +270,6 @@ ggplot() +
     scale_fill_gradientn(name = "Elevation", colors = rainbow(100)) +
     guides(fill = guide_colorbar()) +
     scale_alpha(range = c(0.15, 0.65), guide = "none") +
-    theme(axis.title.x = element_blank(),
-          axis.title.y = element_blank()) +
-    ggtitle("DSM with Hillshade - NEON Harvard Forest Field Site") +
     coord_equal()
 
 ```

--- a/_episodes_rmd/03-raster-reproject-in-r.Rmd
+++ b/_episodes_rmd/03-raster-reproject-in-r.Rmd
@@ -60,15 +60,45 @@ library(ggplot2)
 library(dplyr)
 ```
 
-Let's create a map of the Harvard Forest Digital Terrain Model
+For this episode, we will be working with the Harvard Forest Digital
+Terrain Model data. This differes from the surface model data we've
+we've been working with so far in that the digital terrain model
+(DTM) includes the tops of trees, while the digital surface model
+(DSM) shows the ground level.
+
+<figure>
+<a href="{{ site.baseurl }}/images/dc-spatial-raster/lidarTree-height.png">
+<img src="{{ site.baseurl }}/images/dc-spatial-raster/lidarTree-height.png">
+</a>
+<figcaption> Source: National Ecological Observatory Network (NEON)
+</figcaption>
+</figure>
+
+We'll be looking at another model (the canopy height model) in
+[a later episode]({{ site.baseurl }}/04-raster-calculations-in-r/index.html) and will see how to calculate the CHM from the
+DSM and DTM. Here, we will create a map of the Harvard Forest Digital
+Terrain Model
 (`DTM_HARV`) draped or layered on top of the hillshade (`DTM_hill_HARV`).
+
+First, we need to import the DTM and DTM hillshade data.
 
 ```{r import-DTM-hillshade }
 # import DTM
 DTM_HARV <- raster("data/NEON-DS-Airborne-Remote-Sensing/HARV/DTM/HARV_dtmCrop.tif")
+
+# view data structure
+DTM_HARV
+
 # import DTM hillshade
 DTM_hill_HARV <- raster("data/NEON-DS-Airborne-Remote-Sensing/HARV/DTM/HARV_DTMhill_WGS84.tif")
 
+# view data structure
+DTM_hill_HARV
+```
+
+Next, we will convert each of these datasets to a dataframe.
+
+```{r}
 # convert to data.frames
 DTM_HARV_df <- DTM_HARV  %>% 
   rasterToPoints(., spatial = TRUE) %>% 
@@ -77,7 +107,11 @@ DTM_HARV_df <- DTM_HARV  %>%
 DTM_hill_HARV_df <- DTM_hill_HARV  %>% 
   rasterToPoints(., spatial = TRUE) %>% 
   data.frame()
+```
 
+Now we can create a map of the DTM layered over the hillshade.
+
+```{r}
 ggplot() +
      geom_raster(data = DTM_hill_HARV_df, 
                  aes(x = x, y = y, 
@@ -91,60 +125,31 @@ ggplot() +
      scale_fill_gradientn(name = "Elevation", colors = terrain.colors(10)) +
      guides(fill = guide_colorbar()) +
      scale_alpha(range = c(0.25, 0.65), guide = "none") +
-    theme_bw() +
-    theme(panel.grid.major = element_blank(), 
-          panel.grid.minor = element_blank()) +
-     theme(axis.title.x = element_blank(),
-           axis.title.y = element_blank()) +
-     ggtitle("Digital Terrain Model - NEON Harvard Forest Field Site") +
      coord_equal()
 ```
 
 Our results are curious - neither the Digital Terrain Model (`DTM_HARV_df`) 
-or the DTM Hillshade (`DTM_hill_HARV_df`)did not plot on
+or the DTM Hillshade (`DTM_hill_HARV_df`) plotted.
 Let's try to
 plot the DTM on it's own to make sure there are data there.
 
 ```{r plot-DTM }
 ggplot() +
-     geom_raster(data = DTM_HARV_df , 
-             aes(x = x, y = y, 
-                  fill = HARV_dtmCrop,
-                  alpha=0.8)
-             ) + 
-     scale_fill_gradientn(name = "Elevation", colors = terrain.colors(10)) +
-     guides(fill = guide_colorbar()) +
-     scale_alpha(range = c(0.25, 0.65), guide = "none") +
-    theme_bw() +
-    theme(panel.grid.major = element_blank(), 
-          panel.grid.minor = element_blank()) +
-     theme(axis.title.x = element_blank(),
-           axis.title.y = element_blank()) +
-     ggtitle("Digital Terrain Model - NEON Harvard Forest Field Site") +
-     coord_equal()
-
+geom_raster(data = DTM_HARV_df,
+    aes(x = x, y = y,
+    fill = HARV_dtmCrop)) +
+scale_fill_gradientn(name = "Elevation", colors = terrain.colors(10))
 ```
 
-Our DTM seems to contain data and plots just fine. 
+Our DTM seems to contain data and plots just fine.
 
 Next we plot the DTM Hillshade on it's own to see whether everything is OK.
 
 ```{r plot-DTM-hill}
-
 ggplot() +
-     geom_raster(data = DTM_hill_HARV_df, 
-                 aes(x = x, y = y, 
-                   alpha = HARV_DTMhill_WGS84)
-                 ) +
-     guides(fill = guide_colorbar()) +
-     scale_alpha(range = c(0.25, 0.65), guide = "none") +
-    theme_bw() +
-    theme(panel.grid.major = element_blank(), 
-          panel.grid.minor = element_blank()) +
-     theme(axis.title.x = element_blank(),
-           axis.title.y = element_blank()) +
-     ggtitle("Digital Terrain Model Hillshade - NEON Harvard Forest Field Site") +
-     coord_equal()
+geom_raster(data = DTM_hill_HARV_df,
+    aes(x = x, y = y,
+    alpha = HARV_DTMhill_WGS84))
 ```
 
 Now we see the problem, the projections of the two rasters are different.
@@ -154,16 +159,25 @@ throw an error message.
 Let's next check the
  Coordinate Reference System (CRS) of the DTM and compare it to our hillshade.
 
-```{r explore-crs }
-# view crs for DTM
-crs(DTM_HARV)
+> ## Exercise
+> View the CRS for each of these two datasets. What projection
+> does each use?
+>
+> > ## Solution
+> >
+> > ```{r explore-crs }
+> > # view crs for DTM
+> > crs(DTM_HARV)
+> >
+> > # view crs for hillshade
+> > crs(DTM_hill_HARV)
+> > ```
+> >
+> > `DTM_HARV` is in the UTM projection. `DTM_hill_HARV` is in
+> > `Geographic WGS84` - which is represented by latitude and longitude values.
+> {: .solution}
+{: .challenge}
 
-# view crs for hillshade
-crs(DTM_hill_HARV)
-```
-
-Aha! `DTM_HARV` is in the UTM projection. `DTM_hill_HARV` is in
-`Geographic WGS84` - which is represented by latitude and longitude values.
 Because the two rasters are in different CRSs, they don't line up when plotted
 in `R`. We need to *reproject* `DTM_hill_HARV` into the UTM CRS. Alternatively,
 we could project `DTM_HARV` into WGS84.
@@ -270,17 +284,7 @@ ggplot() +
                   fill = HARV_dtmCrop,
                   alpha=0.8)
              ) + 
-     scale_fill_gradientn(name = "Elevation", colors = terrain.colors(10)) +
-     guides(fill = guide_colorbar()) +
-     scale_alpha(range = c(0.25, 0.65), guide = "none") +
-    theme_bw() +
-    theme(panel.grid.major = element_blank(), 
-          panel.grid.minor = element_blank()) +
-     theme(axis.title.x = element_blank(),
-           axis.title.y = element_blank()) +
-     ggtitle("Digital Terrain Model - NEON Harvard Forest Field Site") +
-     coord_equal()
-
+     scale_fill_gradientn(name = "Elevation", colors = terrain.colors(10))
 ```
 
 We have now successfully draped the Digital Terrain Model on top of our
@@ -324,16 +328,7 @@ field site using the `SJER_DSMhill_WGS84.tif` and `SJER_dsmCrop.tif` files.
 > >                   fill = SJER_dsmCrop,
 > >                   alpha=0.8)
 > >              ) + 
-> >      scale_fill_gradientn(name = "Elevation", colors = terrain.colors(10)) +
-> >      guides(fill = guide_colorbar()) +
-> >      scale_alpha(range = c(0.25, 0.65), guide = "none") +
-> >     theme_bw() +
-> >     theme(panel.grid.major = element_blank(), 
-> >           panel.grid.minor = element_blank()) +
-> >      theme(axis.title.x = element_blank(),
-> >            axis.title.y = element_blank()) +
-> >      ggtitle("DSM with Hillshade - NEON SJER Field Site") +
-> >      coord_equal()
+> >      scale_fill_gradientn(name = "Elevation", colors = terrain.colors(10))
 > > ```
 > {: .solution}
 {: .challenge}

--- a/_episodes_rmd/03-raster-reproject-in-r.Rmd
+++ b/_episodes_rmd/03-raster-reproject-in-r.Rmd
@@ -46,11 +46,11 @@ function in the `raster` package.
 ## Raster Projection in R
 
 In the [Plot Raster Data in R]({{ site.baseurl }}/R/Plot-Rasters-In-R/)
-tutorial, we learned how to layer a raster file on top of a hillshade for a nice
-looking basemap. In this tutorial, all of our data were in the same CRS. What
+episode, we learned how to layer a raster file on top of a hillshade for a nice
+looking basemap. In this episode, all of our data were in the same CRS. What
 happens when things don't line up?
 
-We will use the `raster` and `rgdal` packages in this tutorial.
+We will use the `raster` and `rgdal` packages in this episode.
 
 ```{r load-libraries }
 # load raster package
@@ -340,7 +340,7 @@ field site using the `SJER_DSMhill_WGS84.tif` and `SJER_dsmCrop.tif` files.
 
 If you completed the San Joaquin plotting challenge in the
 [Plot Raster Data in R]({{ site.baseurl }}/R/Plot-Rasters-In-R#challenge-create-dtm--dsm-for-sjer)
-tutorial, how does the map you just created compare to that map?
+episode, how does the map you just created compare to that map?
 
 ```{r challenge-code-reprojection2, echo=FALSE}
 # The maps look identical. Which is what they should be as the only difference

--- a/_episodes_rmd/04-raster-calculations-in-r.Rmd
+++ b/_episodes_rmd/04-raster-calculations-in-r.Rmd
@@ -14,11 +14,11 @@ contributors: [ ]
 packagesLibraries: [raster, rgdal. ggplot, dplyr]
 dateCreated:  2015-10-23
 lastModified: `r format(Sys.time(), "%Y-%m-%d")`
-categories:  [self-paced-tutorial]
+categories:  [self-paced-episode]
 tags: [R, raster, spatial-data-gis]
-tutorialSeries: [raster-data-series]
+episodeSeries: [raster-data-series]
 mainTag: raster-data-series
-description: "This tutorial covers how to subtract one raster from another using
+description: "This episode covers how to subtract one raster from another using
 efficient methods - the overlay function compared to basic subtraction. We also
 cover how to extract pixel values from a set of locations - for example a buffer
 region around plot locations at a field site. Finally, it explains the basic
@@ -37,7 +37,7 @@ knitr_fig_path("04-")
 ```
 
 We often want to combine values of and perform calculations on rasters to create
-a new output raster. This tutorial covers how to subtract one raster from
+a new output raster. This episode covers how to subtract one raster from
 another using basic raster math and the `overlay()` function. It also covers how
 to extract pixel values from a set of locations - for example a buffer region
 around plot locations at a field site.
@@ -59,80 +59,57 @@ buildings, etc. with the influence of ground elevation removed.
     </figcaption>
 </figure>
 
-* Check out more on LiDAR CHM, DTM and DSM in this NEON Data Skills overview tutorial:
-<a href="http://neondataskills.org/self-paced-tutorial/2_LiDAR-Data-Concepts_Activity2/" target="_blank">
-What is a CHM, DSM and DTM? About Gridded, Raster LiDAR Data</a>.
+> ## More Resources
+> * Check out more on LiDAR CHM, DTM and DSM in this NEON Data Skills overview episode:
+> <a href="http://neondataskills.org/self-paced-episode/2_LiDAR-Data-Concepts_Activity2/" target="_blank">
+> What is a CHM, DSM and DTM? About Gridded, Raster LiDAR Data</a>.
+{: .callout}
 
 ### Load the Data
-We will need the `raster` package to import and perform raster calculations. We
-will use the DTM (`NEON-DS-Airborne-Remote-Sensing/HARV/DTM/HARV_dtmCrop.tif`)
-and DSM (`NEON-DS-Airborne-Remote-Sensing/HARV/DSM/HARV_dsmCrop.tif`) from the
-NEON Harvard Forest Field site.
+For this episode, we will use the DTM and DSM from the
+NEON Harvard Forest Field site,
+which we already have loaded in previous episodes.
 
-```{r load-libraries }
-# load raster package
+```{r load-libraries, echo = FALSE}
+# load libraries
 library(raster)
 library(rgdal)
 library(ggplot2)
 library(dplyr)
-
-# view info about the dtm & dsm raster data that we will work with.
-GDALinfo("data/NEON-DS-Airborne-Remote-Sensing/HARV/DTM/HARV_dtmCrop.tif")
-GDALinfo("data/NEON-DS-Airborne-Remote-Sensing/HARV/DSM/HARV_dsmCrop.tif")
-
 ```
 
-As seen from the `geoTiff` tags, both rasters have:
+> ## Exercise
+> Use the `GDALinfo()` function to view information about the DTM and
+> DSM data files. Do the two rasters have the same of different CRSs
+> and resolutions? Do they both have defined minimum and maximum values?
+>
+> > ## Solution
+> > ```{r}
+> > # view info about the dtm & dsm raster data that we will work with.
+> > GDALinfo("data/NEON-DS-Airborne-Remote-Sensing/HARV/DTM/HARV_dtmCrop.tif")
+> > GDALinfo("data/NEON-DS-Airborne-Remote-Sensing/HARV/DSM/HARV_dsmCrop.tif")
+> > ```
+> {: .solution}
+{: .challenge}
 
-* the same CRS,
-* the same resolution
-* defined minimum and maximum values.
+We've already loaded in and worked with these two data files in
+earlier episodes. Let's plot them each once more to remind ourselves
+what this data looks like.
 
-Let's load the data.
-
-``` {r load-plot-data}
-# load the DTM & DSM rasters
-DTM_HARV <- raster("data/NEON-DS-Airborne-Remote-Sensing/HARV/DTM/HARV_dtmCrop.tif")
-DSM_HARV <- raster("data/NEON-DS-Airborne-Remote-Sensing/HARV/DSM/HARV_dsmCrop.tif")
-
-# the data.frame conversions
-DTM_HARV_df <- DTM_HARV  %>% 
-   rasterToPoints(., spatial = TRUE) %>% 
-   data.frame()
- 
-DSM_HARV_df <- DSM_HARV  %>% 
-   rasterToPoints(., spatial = TRUE) %>% 
-   data.frame()
- 
+```{r}
 # plot DTM
  ggplot() +
       geom_raster(data = DTM_HARV_df , 
-              aes(x = x, y = y, 
-                   fill = HARV_dtmCrop)
-              ) + 
-     scale_fill_gradientn(name = "Elevation", colors = terrain.colors(10)) +
-     theme_bw() +
-     theme(panel.grid.major = element_blank(), 
-           panel.grid.minor = element_blank()) +
-     theme(axis.title.x = element_blank(),
-            axis.title.y = element_blank()) +
-     ggtitle("Digital Terrain Model - NEON Harvard Forest Field Site") +
-     coord_equal()
+              aes(x = x, y = y, fill = HARV_dtmCrop)) +
+     scale_fill_gradientn(name = "Elevation", colors = terrain.colors(10))
+```
 
+``` {r}
 # plot DSM
  ggplot() +
       geom_raster(data = DSM_HARV_df , 
-              aes(x = x, y = y, 
-                   fill = HARV_dsmCrop)
-              ) + 
-     scale_fill_gradientn(name = "Elevation", colors = terrain.colors(10)) +
-     theme_bw() +
-     theme(panel.grid.major = element_blank(), 
-           panel.grid.minor = element_blank()) +
-     theme(axis.title.x = element_blank(),
-            axis.title.y = element_blank()) +
-     ggtitle("Digital Surface Model - NEON Harvard Forest Field Site") +
-     coord_equal()
+              aes(x = x, y = y, fill = HARV_dsmCrop)) +
+     scale_fill_gradientn(name = "Elevation", colors = terrain.colors(10))
 ```
 
 ## Two Ways to Perform Raster Calculations
@@ -154,28 +131,22 @@ multiplying, etc) two rasters. In the geospatial world, we call this
 Let's subtract the DTM from the DSM to create a Canopy Height Model.
 
 ```{r raster-math }
-# Raster math example
 CHM_HARV <- DSM_HARV - DTM_HARV
 
 CHM_HARV_df <- CHM_HARV  %>% 
    rasterToPoints(., spatial = TRUE) %>% 
    data.frame()
+```
 
-# plot the output CHM
+We can now plot the output CHM.
+
+```{r}
  ggplot() +
       geom_raster(data = CHM_HARV_df , 
               aes(x = x, y = y, 
                    fill = layer)
               ) + 
-     scale_fill_gradientn(name = "Canopy Height", colors = terrain.colors(10)) +
-     theme_bw() +
-     theme(panel.grid.major = element_blank(), 
-           panel.grid.minor = element_blank()) +
-     theme(axis.title.x = element_blank(),
-            axis.title.y = element_blank()) +
-     ggtitle("Canopy Height Model with Raster Math Subtract \n NEON Harvard Forest Field Site") +
-     coord_equal()
-
+     scale_fill_gradientn(name = "Canopy Height", colors = terrain.colors(10))
 ```
 
 Let's have a look at the distribution of values in our newly created
@@ -184,13 +155,7 @@ Canopy Height Model (CHM).
 ```{r create-hist }
 
 ggplot(CHM_HARV_df) +
-    geom_histogram(aes(layer), colour="black", fill="darkgreen") +
-    theme_bw() +
-    theme(legend.position = "none") +
-    ggtitle("Histogram of Canopy Height Model - NEON Harvard Forest Field Site") +
-    xlab("Tree Height (m) ") +
-    ylab("Number of Pixels")
-
+    geom_histogram(aes(layer))
 ```
 
 Notice that the range of values for the output CHM is between 0 and 30 meters.
@@ -216,21 +181,10 @@ Does this make sense for trees in Harvard Forest?
 > > # slot.
 > > # 3
 > > ggplot(CHM_HARV_df) +
-> >     geom_histogram(aes(layer), colour="black", fill="darkgreen") +
-> >     theme_bw() +
-> >     theme(legend.position = "none") +
-> >     ggtitle("Histogram of Canopy Height Model - NEON Harvard Forest Field Site") +
-> >     xlab("Tree Height (m) ") +
-> >     ylab("Number of Pixels")
+> >     geom_histogram(aes(layer))
 > > # 4
 > > ggplot(CHM_HARV_df) +
-> >     geom_histogram(aes(layer), colour="black", fill="springgreen4", 
-> >                    bins = 6) +
-> >     theme_bw() +
-> >     theme(legend.position = "none") +
-> >     ggtitle("Histogram of Canopy Height Model - NEON Harvard Forest Field Site") +
-> >     xlab("Tree Height (m) ") +
-> >     ylab("Number of Pixels")
+> >     geom_histogram(aes(layer), colour="black", fill="darkgreen", bins = 6)
 > > # 5
 > > custom_bins <- c(0, 10, 20, 30, 40)
 > > CHM_HARV_df <- CHM_HARV_df %>%
@@ -239,14 +193,7 @@ Does this make sense for trees in Harvard Forest?
 > > ggplot() +
 > >   geom_raster(data = CHM_HARV_df , aes(x = x, y = y,
 > >                                        fill = canopy_discrete)) + 
-> >      scale_fill_manual(values = terrain.colors(4)) + 
-> >      ggtitle("Discrete Canopy Heights - NEON Harvard Forest Field Site") +
-> >      theme_bw() +
-> >      theme(panel.grid.major = element_blank(), 
-> >            panel.grid.minor = element_blank()) +
-> >      theme(axis.title.x = element_blank(),
-> >             axis.title.y = element_blank()) +
-> >     coord_equal()
+> >      scale_fill_manual(values = terrain.colors(4))
 > > ```
 > {: .solution}
 {: .challenge}
@@ -281,6 +228,14 @@ them using efficient processing methods. The syntax is
 Let's perform the same subtraction calculation that we calculated above using
 raster math, using the `overlay()` function.
 
+> ## Data Tip
+> A custom function consists of a defined
+> set of commands performed on a input object. Custom functions are particularly
+> useful for tasks that need to be repeated over and over in the code. A
+> simplified syntax for writing a custom function in R is:
+> `functionName <- function(variable1, variable2){WhatYouWantDone, WhatToReturn}`
+{: .callout}
+
 ```{r raster-overlay }
 CHM_ov_HARV <- overlay(DSM_HARV,
                        DTM_HARV,
@@ -296,26 +251,11 @@ CHM_ov_HARV_df <- CHM_ov_HARV %>%
               aes(x = x, y = y, 
                    fill = layer)
               ) + 
-     scale_fill_gradientn(name = "Canopy Height", colors = terrain.colors(10)) +
-     theme_bw() +
-     theme(panel.grid.major = element_blank(), 
-           panel.grid.minor = element_blank()) +
-     theme(axis.title.x = element_blank(),
-            axis.title.y = element_blank()) +
-     ggtitle("Canopy Height Model with Overlay Subtract \n NEON Harvard Forest Field Site") +
-     coord_equal()
+     scale_fill_gradientn(name = "Canopy Height", colors = terrain.colors(10))
 ```
 
 How do the plots of the CHM created with manual raster math and the `overlay()`
 function compare?
-
-> ## Data Tip
-> A custom function consists of a defined
-> set of commands performed on a input object. Custom functions are particularly
-> useful for tasks that need to be repeated over and over in the code. A
-> simplified syntax for writing a custom function in R is:
-> `functionName <- function(variable1, variable2){WhatYouWantDone, WhatToReturn}`
-{: .callout}
 
 ## Export a GeoTIFF
 Now that we've created a new raster, let's export the data as a `GeoTIFF` using
@@ -366,7 +306,7 @@ in Massachusetts.
 > 1. Import the DSM and DTM from the SJER directory (if not aready imported
 in the
 > [Plot Raster Data in R]({{ site.baseurl }}/R/Plot-Rasters-In-R/)
-tutorial.) Don't forget to examine the data for `CRS`, bad values, etc.
+episode.) Don't forget to examine the data for `CRS`, bad values, etc.
 > 2. Create a `CHM` from the two raster layers and check to make sure the data
 are what you expect.
 > 3. Plot the `CHM` from SJER.
@@ -399,21 +339,11 @@ both datasets!
 > > 
 > > # check values
 > > ggplot(DTM_SJER_df) +
-> >     geom_histogram(aes(SJER_dtmCrop), colour="black", fill="blue") +
-> >     theme_bw() +
-> >     theme(legend.position = "none") +
-> >     ggtitle("Digital Terrain Model Histogram - NEON SJER Field Site") +
-> >     xlab("Elevation (m)") +
-> >     ylab("Number of Pixels")
-> > 
+> >     geom_histogram(aes(SJER_dtmCrop))
+> >
 > > ggplot(DSM_SJER_df) +
-> >     geom_histogram(aes(SJER_dsmCrop), colour="black", fill="red") +
-> >     theme_bw() +
-> >     theme(legend.position = "none") +
-> >     ggtitle("Digital Surface Model Histogram - NEON SJER Field Site") +
-> >     xlab("Elevation (m)") +
-> >     ylab("Number of Pixels")
-> > 
+> >     geom_histogram(aes(SJER_dsmCrop))
+> >
 > > # 2.
 > > # use overlay to subtract the two rasters & create CHM
 > > CHM_ov_SJER <- overlay(DSM_SJER,
@@ -425,12 +355,7 @@ both datasets!
 > >    data.frame()
 > > 
 > > ggplot(CHM_ov_SJER_df) +
-> >     geom_histogram(aes(layer), colour="black", fill="dodgerblue") +
-> >     theme_bw() +
-> >     theme(legend.position = "none") +
-> >     ggtitle("Histogram of Canopy Height Model - NEON SJER Site") +
-> >     xlab("Canopy Height (m) ") +
-> >     ylab("Number of Pixels")
+> >     geom_histogram(aes(layer))
 > > 
 > > # 3
 > > # plot the output
@@ -439,15 +364,8 @@ both datasets!
 > >               aes(x = x, y = y, 
 > >                    fill = layer)
 > >               ) + 
-> >      scale_fill_gradientn(name = "Canopy Height", colors = terrain.colors(10)) +
-> >      theme_bw() +
-> >      theme(panel.grid.major = element_blank(), 
-> >            panel.grid.minor = element_blank()) +
-> >      theme(axis.title.x = element_blank(),
-> >             axis.title.y = element_blank()) +
-> >      ggtitle("Canopy Height Model - NEON SJER Site") +
-> >      coord_equal()
-> > 
+> >      scale_fill_gradientn(name = "Canopy Height", colors = terrain.colors(10))
+> >
 > > # 4
 > > # Write to object to file
 > > writeRaster(CHM_ov_SJER, "chm_ov_SJER.tiff",
@@ -459,21 +377,11 @@ both datasets!
 > > # view histogram of HARV again.
 > > par(mfcol = c(2, 1))
 > > ggplot(CHM_HARV_df) +
-> >     geom_histogram(aes(layer), colour="black", fill="darkgreen") +
-> >     theme_bw() +
-> >     theme(legend.position = "none") +
-> >     ggtitle("Histogram of Canopy Height Model - NEON Harvard Forest Field Site") +
-> >     xlab("Tree Height (m) ") +
-> >     ylab("Number of Pixels")
-> > 
+> >     geom_histogram(aes(layer))
+> >
 > > ggplot(CHM_ov_SJER_df) +
-> >     geom_histogram(aes(layer), colour="black", fill="dodgerblue") +
-> >     theme_bw() +
-> >     theme(legend.position = "none") +
-> >     ggtitle("Histogram of Canopy Height Model - NEON SJER Site") +
-> >     xlab("Canopy Height (m) ") +
-> >     ylab("Number of Pixels")
-> > 
+> >     geom_histogram(aes(layer))
+> >
 > > ```
 > {: .solution}
 {: .challenge}


### PR DESCRIPTION
This PR implements the following suggestions from https://github.com/datacarpentry/r-raster-vector-geospatial/issues/165:

[Episode 2](http://www.datacarpentry.org/r-raster-vector-geospatial/02-raster-plot/index.html)
- [ ] Remove repetitive steps in intro. We can assume that learners are completing the episodes in order, so we can remove anything that happened in episode 1. This will also help Maintainers as changes only need to be made in one place, rather that in every location where the information is repeated.
- [ ] Remove calls to `xlab`, `ylab`, and `ggtitle` for reasons discussed above.
- [ ] Mention `( ]` notation in callout. Some learners may not be familiar with the inclusive, exclusive range notation.
- [ ] In the "Layering Rasters" section split the code chunks as in the first episode.

[Episode 3](http://www.datacarpentry.org/r-raster-vector-geospatial/03-raster-reproject-in-r/index.html) 
- [ ] Remove axis labels and titles for reasons discussed above. Simplify plotting calls as much as possible.

[Episode 4](http://www.datacarpentry.org/r-raster-vector-geospatial/04-raster-calculations-in-r/index.html)
- [ ] Change "tutorial" to "episode" throughout (for consistency in terminology with other Carpentries lessons).
- [ ] Learners have already loaded in the data for this episode. Remove that redundancy to avoid confusion. 
- [ ] Keep GDALinfo calls but ask learners to interpret something from them (challenge)
- [ ] Simplify ggplot calls as in other episodes.
- [ ] Move data tip about custom function definitions to before the learners implement overlay for the first time.