### PR TITLE
More cleanup

### DIFF
--- a/_episodes_rmd/01-raster-structure.Rmd
+++ b/_episodes_rmd/01-raster-structure.Rmd
@@ -40,6 +40,13 @@ library(dplyr)
 >
 > * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
 > * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
+>
+> ### Setup RStudio Project
+>
+> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
+>
+> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
+>
 {: .prereq}
 
 In this episode, we will review the fundamental principles, packages and

--- a/_episodes_rmd/01-raster-structure.Rmd
+++ b/_episodes_rmd/01-raster-structure.Rmd
@@ -13,7 +13,6 @@ objectives:
 -  "Understand the difference between single- and multi-band rasters."
 keypoints:
 -  "The Coordinate Reference System or CRS tells R where the raster is located in geographic space and what method should be used to “flatten” or project the raster."
-authors: [Leah A. Wasser, Megan A. Jones, Zack Brym, Kristina Riemer, Jason Williams, Jeff Hollister,  Mike Smorul, Joseph Stachelek]
 ---
 
 ```{r setup, echo=FALSE}

--- a/_episodes_rmd/01-raster-structure.Rmd
+++ b/_episodes_rmd/01-raster-structure.Rmd
@@ -29,7 +29,7 @@ library(ggplot2)
 library(dplyr)
 ```
 
-> ## Things You’ll Need To Complete This episode
+> ## Things You’ll Need To Complete This Episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
 > ### Install software

--- a/_episodes_rmd/01-raster-structure.Rmd
+++ b/_episodes_rmd/01-raster-structure.Rmd
@@ -1,8 +1,8 @@
 ---
 source: Rmd
 title: "Intro to Raster Data in R"
-teaching: 10
-exercises: 2
+teaching: 20
+exercises: 10
 questions:
 -  "What is a raster dataset?"
 objectives:
@@ -22,7 +22,7 @@ knitr_fig_path("01-")
 knitr::opts_chunk$set(fig.height = 6)
 ```
 
-```{r load-libraries, echo = FALSE}
+```{r load-libraries, echo = FALSE, results='hide'}
 library(raster)
 library(rgdal)
 library(ggplot2)
@@ -30,22 +30,8 @@ library(dplyr)
 ```
 
 > ## Things You’ll Need To Complete This Episode
-> **R Skill Level:** Intermediate - you've got the basics of `R` down.
->
-> ### Install software
-> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
->
-> ### Download Data
->
-> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
-> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
->
-> ### Setup RStudio Project
->
-> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
->
-> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
->
+> See the [lesson homepage]({{ site.baseurl }}) for detailed information about the software,
+> data, and other prerequisites you will need to work through the examples in this episode.
 {: .prereq}
 
 In this episode, we will review the fundamental principles, packages and

--- a/_episodes_rmd/02-raster-plot.Rmd
+++ b/_episodes_rmd/02-raster-plot.Rmd
@@ -9,23 +9,6 @@ objectives:
 - "Know how to layer a raster dataset on top of a hillshade to create an elegant basemap."
 keypoints:
 - ""
-authors: [Leah A. Wasser, Megan A. Jones, Zack Brym, Kristina Riemer, Jason Williams, Jeff Hollister,  Mike Smorul, Joseph Stachelek]
-contributors: [ ]
-packagesLibraries: [raster, rgdal, dplyr, ggplot2]
-dateCreated:  2015-10-23
-lastModified: `r format(Sys.time(), "%Y-%m-%d")`
-categories:  [self-paced-tutorial]
-tags: [R, raster, spatial-data-gis]
-tutorialSeries: [raster-data-series]
-mainTag: raster-data-series
-description: "This tutorial explains how to plot a raster in R using R's base plot
-function. It also covers how to layer a raster on top of a hillshade to produce
-an eloquent map."
-image:
-  feature: NEONCarpentryHeader_2.png
-  credit: A collaboration between the National Ecological Observatory Network (NEON) and Data Carpentry
-  creditlink:
-comments: true
 ---
 
 ```{r setup, echo=FALSE}

--- a/_episodes_rmd/02-raster-plot.Rmd
+++ b/_episodes_rmd/02-raster-plot.Rmd
@@ -50,6 +50,26 @@ DSM_HARV_df <- rasterToPoints(DSM_HARV, spatial = TRUE) %>%
 data.frame()
 ```
 
+> ## Things You’ll Need To Complete This episode
+> **R Skill Level:** Intermediate - you've got the basics of `R` down.
+>
+> ### Install software
+> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
+>
+> ### Download Data
+>
+> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
+> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
+>
+> ### Setup RStudio Project
+>
+> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
+>
+> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
+>
+{: .prereq}
+
+
 This episode covers how to plot a raster in `R` using the `ggplot2`
 package. It also covers how to layer a raster on top of a hillshade to produce
 an eloquent map.

--- a/_episodes_rmd/02-raster-plot.Rmd
+++ b/_episodes_rmd/02-raster-plot.Rmd
@@ -33,7 +33,7 @@ DSM_HARV_df <- rasterToPoints(DSM_HARV, spatial = TRUE) %>%
 data.frame()
 ```
 
-> ## Things You’ll Need To Complete This episode
+> ## Things You’ll Need To Complete This Episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
 > ### Install software

--- a/_episodes_rmd/02-raster-plot.Rmd
+++ b/_episodes_rmd/02-raster-plot.Rmd
@@ -295,7 +295,7 @@ Range field site.
 > 
 > * include hillshade in the maps,
 > * label axes on the DSM map and exclude them from the DTM map,
-> * a title for the maps,
+> * include a title for each map,
 > * experiment with various alpha values and color palettes to represent the
  data.
 >
@@ -306,21 +306,15 @@ Range field site.
 > > 
 > > # import DSM data
 > > DSM_SJER <- raster("data/NEON-DS-Airborne-Remote-Sensing/SJER/DSM/SJER_dsmCrop.tif")
-> > # convert to a df for plotting in two steps,
-> > # First, to a SpatialPointsDataFrame
-> > DSM_SJER_pts <- rasterToPoints(DSM_SJER, spatial = TRUE)
-> > # Then to a 'conventional' dataframe
-> > DSM_SJER_df  <- data.frame(DSM_SJER_pts)
-> > rm(DSM_SJER_pts, DSM_SJER)
-> > 
+> > # convert to a df for plotting
+> > DSM_SJER_df <- rasterToPoints(DSM_SJER, spatial = TRUE) %>%
+> >     data.frame()
+> >
 > > # import DSM hillshade
 > > DSM_hill_SJER <- raster("data/NEON-DS-Airborne-Remote-Sensing/SJER/DSM/SJER_dsmHill.tif")
-> > # convert to a df for plotting in two steps,
-> > # First, to a SpatialPointsDataFrame
-> > DSM_hill_SJER_pts <- rasterToPoints(DSM_hill_SJER, spatial = TRUE)
-> > # Then to a 'conventional' dataframe
-> > DSM_hill_SJER_df  <- data.frame(DSM_hill_SJER_pts)
-> > rm(DSM_hill_SJER_pts, DSM_hill_SJER)
+> > # convert to a df for plotting
+> > DSM_hill_SJER_df <- rasterToPoints(DSM_hill_SJER, spatial = TRUE) %>%
+> >     data.frame()
 > > 
 > > # Build Plot
 > > ggplot() +
@@ -342,21 +336,19 @@ Range field site.
 > >           panel.grid.minor = element_blank()) +
 > >     xlab("UTM Westing Coordinate (m)") +
 > >     ylab("UTM Northing Coordinate (m)") +
-> >     ggtitle("DSM with Hillshade - NEON SJER Field Site") +
+> >     ggtitle("DSM with Hillshade") +
 > >     coord_equal()
 > > 
-> > # CREATE SJER DTM MAP
+> > # CREATE DTM MAP
 > > # import DTM
 > > DTM_SJER <- raster("data/NEON-DS-Airborne-Remote-Sensing/SJER/DTM/SJER_dtmCrop.tif")
-> > DTM_SJER_pts <- rasterToPoints(DTM_SJER, spatial = TRUE)
-> > DTM_SJER_df  <- data.frame(DTM_SJER_pts)
-> > rm(DTM_SJER_pts, DTM_SJER)
+> > DTM_SJER_df <- rasterToPoints(DTM_SJER, spatial = TRUE) %>%
+> >     data.frame()
 > >
 > > # DTM Hillshade
 > > DTM_hill_SJER <- raster("data/NEON-DS-Airborne-Remote-Sensing/SJER/DTM/SJER_dtmHill.tif")
-> > DTM_hill_SJER_pts <- rasterToPoints(DTM_hill_SJER, spatial = TRUE)
-> > DTM_hill_SJER_df  <- data.frame(DTM_hill_SJER_pts)
-> > rm(DTM_hill_SJER_pts, DTM_hill_SJER)
+> > DTM_hill_SJER_df <- rasterToPoints(DTM_hill_SJER, spatial = TRUE) %>%
+> >     data.frame()
 > > 
 > > ggplot() +
 > >     geom_raster(data = DTM_SJER_df ,
@@ -376,7 +368,7 @@ Range field site.
 > >           panel.grid.minor = element_blank()) +
 > >     theme(axis.title.x = element_blank(),
 > >           axis.title.y = element_blank()) +
-> >     ggtitle("DTM with Hillshade - NEON SJER Field Site") +
+> >     ggtitle("DTM with Hillshade") +
 > >     coord_equal()
 > > ```
 > {: .solution}

--- a/_episodes_rmd/02-raster-plot.Rmd
+++ b/_episodes_rmd/02-raster-plot.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Plot Raster Data in R"
-teaching: 10
-exercises: 0
+teaching: 20
+exercises: 10
 questions:
 - ""
 objectives:
@@ -17,7 +17,7 @@ source("../setup.R")
 knitr_fig_path("02-")
 ```
 
-```{r load-libraries, echo = FALSE}
+```{r load-libraries, echo = FALSE, results='hide'}
 library(raster)
 library(rgdal)
 library(ggplot2)
@@ -34,24 +34,9 @@ data.frame()
 ```
 
 > ## Things You’ll Need To Complete This Episode
-> **R Skill Level:** Intermediate - you've got the basics of `R` down.
->
-> ### Install software
-> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
->
-> ### Download Data
->
-> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
-> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
->
-> ### Setup RStudio Project
->
-> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
->
-> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
->
+> See the [lesson homepage]({{ site.baseurl }}) for detailed information about the software,
+> data, and other prerequisites you will need to work through the examples in this episode.
 {: .prereq}
-
 
 This episode covers how to plot a raster in `R` using the `ggplot2`
 package. It also covers how to layer a raster on top of a hillshade to produce

--- a/_episodes_rmd/03-raster-reproject-in-r.Rmd
+++ b/_episodes_rmd/03-raster-reproject-in-r.Rmd
@@ -8,25 +8,6 @@ objectives:
 - "Be able to reproject a raster in `R`."
 keypoints:
 - ""
-authors: [Leah A. Wasser, Megan A. Jones, Zack Brym, Kristina Riemer, Jason Williams, Jeff Hollister,  Mike Smorul, Joseph Stachelek]
-contributors: [Michael Heeremans]
-packagesLibraries: [raster, rgdal, ggplot2]
-dateCreated:  2015-10-23
-lastModified: `r format(Sys.time(), "%Y-%m-%d")`
-categories:  [self-paced-tutorial]
-tags: [R, raster, spatial-data-gis]
-tutorialSeries: [raster-data-series]
-mainTag: raster-data-series
-description: "This tutorial explores issues associated with working with rasters
-in different Coordinate Reference Systems (CRS) / projections. When two rasters
-are in different CRS, they will not plot nicely together on a map. We will learn
-how to reproject a raster in R using the projectRaster function in the raster
-package."
-image:
-  feature: NEONCarpentryHeader_2.png
-  credit: A collaboration between the National Ecological Observatory Network (NEON) and Data Carpentry
-  creditlink:
-comments: true
 ---
 
 ```{r setup, echo=FALSE}
@@ -65,7 +46,7 @@ Sometimes we encounter raster datasets that do not "line up" when plotted or
 analyzed. Rasters that don't line up are most often in different Coordinate
 Reference Systems (CRS).
 
-This tutorial explains how to deal with rasters in different, known CRSs. It
+This episode explains how to deal with rasters in different, known CRSs. It
 will walk though reprojecting rasters in `R` using the `projectRaster()`
 function in the `raster` package.
 

--- a/_episodes_rmd/03-raster-reproject-in-r.Rmd
+++ b/_episodes_rmd/03-raster-reproject-in-r.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Reproject Raster Data in R"
-teaching: 10
-exercises: 0
+teaching: 20
+exercises: 10
 questions:
 - "What to do when rasters don't line up."
 objectives:
@@ -16,7 +16,7 @@ source("../setup.R")
 knitr_fig_path("03-")
 ```
 
-```{r load-libraries, echo = FALSE}
+```{r load-libraries, echo = FALSE, results='hide'}
 library(raster)
 library(rgdal)
 library(ggplot2)
@@ -24,22 +24,8 @@ library(dplyr)
 ```
 
 > ## Things You’ll Need To Complete This Episode
-> **R Skill Level:** Intermediate - you've got the basics of `R` down.
->
-> ### Install software
-> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
->
-> ### Download Data
->
-> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
-> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
->
-> ### Setup RStudio Project
->
-> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
->
-> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
->
+> See the [lesson homepage]({{ site.baseurl }}) for detailed information about the software,
+> data, and other prerequisites you will need to work through the examples in this episode.
 {: .prereq}
 
 Sometimes we encounter raster datasets that do not "line up" when plotted or

--- a/_episodes_rmd/03-raster-reproject-in-r.Rmd
+++ b/_episodes_rmd/03-raster-reproject-in-r.Rmd
@@ -23,7 +23,7 @@ library(ggplot2)
 library(dplyr)
 ```
 
-> ## Things You’ll Need To Complete This episode
+> ## Things You’ll Need To Complete This Episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
 > ### Install software

--- a/_episodes_rmd/03-raster-reproject-in-r.Rmd
+++ b/_episodes_rmd/03-raster-reproject-in-r.Rmd
@@ -42,6 +42,25 @@ library(ggplot2)
 library(dplyr)
 ```
 
+> ## Things You’ll Need To Complete This episode
+> **R Skill Level:** Intermediate - you've got the basics of `R` down.
+>
+> ### Install software
+> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
+>
+> ### Download Data
+>
+> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
+> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
+>
+> ### Setup RStudio Project
+>
+> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
+>
+> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
+>
+{: .prereq}
+
 Sometimes we encounter raster datasets that do not "line up" when plotted or
 analyzed. Rasters that don't line up are most often in different Coordinate
 Reference Systems (CRS).

--- a/_episodes_rmd/04-raster-calculations-in-r.Rmd
+++ b/_episodes_rmd/04-raster-calculations-in-r.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Raster Calculations in R"
-teaching: 10
-exercises: 0
+teaching: 20
+exercises: 10
 questions:
 - "How to subtract one raster from another and extract pixel values for defined locations."
 objectives:
@@ -17,7 +17,7 @@ source("../setup.R")
 knitr_fig_path("04-")
 ```
 
-```{r load-libraries, echo = FALSE}
+```{r load-libraries, echo = FALSE, results='hide'}
 library(raster)
 library(rgdal)
 library(ggplot2)
@@ -40,22 +40,8 @@ data.frame()
 ```
 
 > ## Things You’ll Need To Complete This Episode
-> **R Skill Level:** Intermediate - you've got the basics of `R` down.
->
-> ### Install software
-> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
->
-> ### Download Data
->
-> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
-> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
->
-> ### Setup RStudio Project
->
-> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
->
-> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
->
+> See the [lesson homepage]({{ site.baseurl }}) for detailed information about the software,
+> data, and other prerequisites you will need to work through the examples in this episode.
 {: .prereq}
 
 

--- a/_episodes_rmd/04-raster-calculations-in-r.Rmd
+++ b/_episodes_rmd/04-raster-calculations-in-r.Rmd
@@ -9,25 +9,6 @@ objectives:
 - "Know how to perform a more efficient subtraction (difference) between two rasters using the raster `overlay()` function in R."
 keypoints:
 - ""
-authors: [Leah A. Wasser, Megan A. Jones, Zack Brym, Kristina Riemer, Jason Williams, Jeff Hollister,  Mike Smorul, Joseph Stachelek]
-contributors: [ ]
-packagesLibraries: [raster, rgdal. ggplot, dplyr]
-dateCreated:  2015-10-23
-lastModified: `r format(Sys.time(), "%Y-%m-%d")`
-categories:  [self-paced-episode]
-tags: [R, raster, spatial-data-gis]
-episodeSeries: [raster-data-series]
-mainTag: raster-data-series
-description: "This episode covers how to subtract one raster from another using
-efficient methods - the overlay function compared to basic subtraction. We also
-cover how to extract pixel values from a set of locations - for example a buffer
-region around plot locations at a field site. Finally, it explains the basic
-principles of writing functions in R."
-image:
-  feature: NEONCarpentryHeader_2.png
-  credit: A collaboration between the National Ecological Observatory Network (NEON) and Data Carpentry
-  creditlink:
-comments: true
 ---
 
 ```{r setup, echo=FALSE}

--- a/_episodes_rmd/04-raster-calculations-in-r.Rmd
+++ b/_episodes_rmd/04-raster-calculations-in-r.Rmd
@@ -58,6 +58,26 @@ DTM_HARV_df <- rasterToPoints(DTM_HARV, spatial = TRUE) %>%
 data.frame()
 ```
 
+> ## Things You’ll Need To Complete This episode
+> **R Skill Level:** Intermediate - you've got the basics of `R` down.
+>
+> ### Install software
+> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
+>
+> ### Download Data
+>
+> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
+> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
+>
+> ### Setup RStudio Project
+>
+> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
+>
+> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
+>
+{: .prereq}
+
+
 We often want to combine values of and perform calculations on rasters to create
 a new output raster. This episode covers how to subtract one raster from
 another using basic raster math and the `overlay()` function. It also covers how

--- a/_episodes_rmd/04-raster-calculations-in-r.Rmd
+++ b/_episodes_rmd/04-raster-calculations-in-r.Rmd
@@ -39,7 +39,7 @@ DTM_HARV_df <- rasterToPoints(DTM_HARV, spatial = TRUE) %>%
 data.frame()
 ```
 
-> ## Things You’ll Need To Complete This episode
+> ## Things You’ll Need To Complete This Episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
 > ### Install software

--- a/_episodes_rmd/05-raster-multi-band-in-r.Rmd
+++ b/_episodes_rmd/05-raster-multi-band-in-r.Rmd
@@ -11,18 +11,6 @@ objectives:
 - "Understand what a `NoData` value is in a raster."
 keypoints:
 - "A single raster file can contain multiple bands or layers."
-authors: [Leah A. Wasser, Megan A. Jones, Zack Brym, Kristina Riemer, Jason Williams, Jeff Hollister,  Mike Smorul, Joseph Stachelek]
-contributors: [ ]
-packagesLibraries: [raster, rgdal]
-dateCreated:  2015-10-23
-lastModified: `r format(Sys.time(), "%Y-%m-%d")`
-categories:  [self-paced-tutorial]
-tags: [R, raster, spatial-data-gis]
-tutorialSeries: [raster-data-series, raster-time-series]
-mainTag: raster-data-series
-description: "This tutorial explores how to import and plot a multi-band raster in
-R. It also covers how to plot a three-band color image using the plotRGB
-function in R."
 ---
 
 ```{r setup, echo=FALSE}
@@ -50,7 +38,7 @@ knitr_fig_path("05-")
 >
 {: .prereq}
 
-This tutorial explores how to import and plot a multi-band raster in
+This episode explores how to import and plot a multi-band raster in
 R. It also covers how to plot a three-band color image using the `plotRGB()`
 function in `R`.
 
@@ -60,7 +48,7 @@ function in `R`.
 
 ## About Raster Bands in R
 As discussed in the
-[Intro to Raster Data tutorial]({{ base.url }}/R/Introduction-to-Raster-Data-In-R),
+[Intro to Raster Data episode]({{ base.url }}/R/Introduction-to-Raster-Data-In-R),
 a raster can contain 1 or more bands.
 
 <figure>
@@ -158,7 +146,7 @@ to learn more about time series stacks.
 (multi-spectral) or more than 10-15 (hyperspectral) bands. Check out the NEON
 Data Skills
 [Imaging Spectroscopy HDF5 in R ]({{site.baseurl}}/HDF5/Imaging-Spectroscopy-HDF5-In-R/)
-tutorial for more about working with hyperspectral data cubes.
+episode for more about working with hyperspectral data cubes.
 
 ## Getting Started with Multi-Band Data in R
 To work with multi-band raster data we will use the `raster` and `rgdal`
@@ -173,7 +161,7 @@ library(rgdal)
 
 ```
 
-In this tutorial, the multi-band data that we are working with is imagery
+In this episode, the multi-band data that we are working with is imagery
 collected using the
 <a href="http://www.neonscience.org/science-design/collection-methods/airborne-remote-sensing"
 target="_blank">NEON Airborne Observation Platform</a>
@@ -418,7 +406,7 @@ between 0 and 255.
 > you check?
 > 
 > Answer the questions above using the functions we have covered so far in this
-tutorial.
+episode.
 > 
 > > ## Answers
 > > ``` {r challenge-code-NoData, echo=TRUE, results="hide"}
@@ -453,7 +441,7 @@ tutorial.
 > We can create a RasterStack from
 > several, individual single-band GeoTIFFs too. Check out:
 > [Raster Time Series Data in R]({{ site.baseurl }}/R/Raster-Times-Series-Data-In-R/)
-> for a tutorial on how to do this.
+> for a episode on how to do this.
 {: .callout}
 
 ## RasterStack vs RasterBrick in R

--- a/_episodes_rmd/05-raster-multi-band-in-r.Rmd
+++ b/_episodes_rmd/05-raster-multi-band-in-r.Rmd
@@ -19,6 +19,13 @@ source("../setup.R")
 knitr_fig_path("05-")
 ```
 
+```{r load-libraries, echo = FALSE}
+library(raster)
+library(rgdal)
+library(ggplot2)
+library(dplyr)
+```
+
 > ## Things You’ll Need To Complete This episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
@@ -38,128 +45,11 @@ knitr_fig_path("05-")
 >
 {: .prereq}
 
-This episode explores how to import and plot a multi-band raster in
+We introduced multi-band raster data in
+[an earlier lesson](http://www.datacarpentry.org/organization-geospatial/01-spatial-data-structures-formats/index.html). This episode explores how to import and plot
+a multi-band raster in
 R. It also covers how to plot a three-band color image using the `plotRGB()`
 function in `R`.
-
-## The Basics of Imagery - About Spectral Remote Sensing Data
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/3iaFzafWJQE" frameborder="0" allowfullscreen></iframe>
-
-## About Raster Bands in R
-As discussed in the
-[Intro to Raster Data episode]({{ base.url }}/R/Introduction-to-Raster-Data-In-R),
-a raster can contain 1 or more bands.
-
-<figure>
-    <a href="{{ site.baseurl }}/images/dc-spatial-raster/single_multi_raster.png">
-    <img src="{{ site.baseurl }}/images/dc-spatial-raster/single_multi_raster.png">
-    </a>
-    <figcaption>A raster can contain one or more bands. We can use the
-    raster function to import one single band from a single OR multi-band
-    raster.  Source: National Ecological Observatory Network (NEON).</figcaption>
-</figure>
-
-To work with multi-band rasters in `R`, we need to change how we import and plot
-our data in several ways.
-
-* To import multi band raster data we will use the `stack()` function.
-* If our multi-band data are imagery that we wish to composite, we can use
-`plotRGB()` (instead of `plot()`) to plot a 3 band raster image.
-
-## About Multi-Band Imagery
-One type of multi-band raster dataset that is familiar to many of us is a color
-image. A basic color image consists of three bands: red, green, and blue. Each
-band represents light reflected from the red, green or blue portions of the
-electromagnetic spectrum. The pixel brightness for each band, when composited
-creates the colors that we see in an image.
-
-<figure>
-    <a href="{{ site.baseurl }}/images/dc-spatial-raster/RGBSTack_1.jpg">
-    <img src="{{ site.baseurl }}/images/dc-spatial-raster/RGBSTack_1.jpg"></a>
-    <figcaption>A color image consists of 3 bands - red, green and blue. When
-    rendered together in a GIS, or even a tool like Photoshop or any other
-    image software, they create a color image.
-	Source: National Ecological Observatory Network (NEON).
-    </figcaption>
-</figure>
-
-We can plot each band of a multi-band image individually.
-
-> ## Data Tip
-> In many GIS applications, a single band
-> would render as a single image in grayscale. We will therefore use a grayscale
-> palette to render individual bands.
-{: .callout}
-
-```{r demonstrate-RGB-Image, echo=FALSE}
-library(raster)
-# Use stack function to read in all bands
-RGB_stack_HARV <- stack("data/NEON-DS-Airborne-Remote-Sensing/HARV/RGB_Imagery/HARV_RGB_Ortho.tif")
-
-names(RGB_stack_HARV) <- c("Red Band", "Green Band", "Blue Band")
-
-grayscale_colors <- gray.colors(100,
-                                start = 0.0,
-                                end = 1.0,
-                                gamma = 2.2,
-                                alpha = NULL)
-
-# Create an RGB image from the raster stack
-plot(RGB_stack_HARV,
-     col = grayscale_colors,
-     axes = FALSE)
-
-```
-
-Or we can composite all three bands together to make a color image.
-
-```{r plot-RGB-now, echo=FALSE, message=FALSE }
-# Create an RGB image from the raster stack
-
-original_par <- par() # create original par for easy reversal at end
-par(col.axis = "white", col.lab = "white", tck = 0)
-plotRGB(RGB_stack_HARV, r = 1, g = 2, b = 3,
-        axes = TRUE,
-        main = "3 Band Color Composite Image\n NEON Harvard Forest Field Site")
-box(col = "white")
-
-```
-
-In a multi-band dataset, the rasters will always have the same *extent*,
-*CRS* and *resolution*.
-
-```{r reset-par, echo=FALSE, results="hide", warning=FALSE}
-par(original_par) # go back to original par
-
-```
-
-
-## Other Types of Multi-band Raster Data
-
-Multi-band raster data might also contain:
-
-1. **Time series:** the same variable, over the same area, over time. Check out
-[Raster Time Series Data in R ]({{site.baseurl}}/R/Raster-Times-Series-Data-In-R/)
-to learn more about time series stacks.
-2. **Multi or hyperspectral imagery:** image rasters that have 4 or more
-(multi-spectral) or more than 10-15 (hyperspectral) bands. Check out the NEON
-Data Skills
-[Imaging Spectroscopy HDF5 in R ]({{site.baseurl}}/HDF5/Imaging-Spectroscopy-HDF5-In-R/)
-episode for more about working with hyperspectral data cubes.
-
-## Getting Started with Multi-Band Data in R
-To work with multi-band raster data we will use the `raster` and `rgdal`
-packages.
-
-```{r load-libraries }
-
-# work with raster data
-library(raster)
-# export GeoTIFFs and other core GIS functions
-library(rgdal)
-
-```
 
 In this episode, the multi-band data that we are working with is imagery
 collected using the

--- a/_episodes_rmd/05-raster-multi-band-in-r.Rmd
+++ b/_episodes_rmd/05-raster-multi-band-in-r.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Work With Multi-Band Rasters in R"
-teaching: 10
-exercises: 0
+teaching: 20
+exercises: 10
 questions:
 - ""
 objectives:
@@ -19,7 +19,7 @@ source("../setup.R")
 knitr_fig_path("05-")
 ```
 
-```{r load-libraries, echo = FALSE}
+```{r load-libraries, echo = FALSE, results='hide'}
 library(raster)
 library(rgdal)
 library(ggplot2)
@@ -27,22 +27,8 @@ library(dplyr)
 ```
 
 > ## Things You’ll Need To Complete This Episode
-> **R Skill Level:** Intermediate - you've got the basics of `R` down.
->
-> ### Install software
-> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
->
-> ### Download Data
->
-> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
-> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
->
-> ### Setup RStudio Project
->
-> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
->
-> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
->
+> See the [lesson homepage]({{ site.baseurl }}) for detailed information about the software,
+> data, and other prerequisites you will need to work through the examples in this episode.
 {: .prereq}
 
 We introduced multi-band raster data in

--- a/_episodes_rmd/05-raster-multi-band-in-r.Rmd
+++ b/_episodes_rmd/05-raster-multi-band-in-r.Rmd
@@ -26,7 +26,7 @@ library(ggplot2)
 library(dplyr)
 ```
 
-> ## Things You’ll Need To Complete This episode
+> ## Things You’ll Need To Complete This Episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
 > ### Install software

--- a/_episodes_rmd/05-raster-multi-band-in-r.Rmd
+++ b/_episodes_rmd/05-raster-multi-band-in-r.Rmd
@@ -31,6 +31,25 @@ source("../setup.R")
 knitr_fig_path("05-")
 ```
 
+> ## Things You’ll Need To Complete This episode
+> **R Skill Level:** Intermediate - you've got the basics of `R` down.
+>
+> ### Install software
+> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
+>
+> ### Download Data
+>
+> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
+> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
+>
+> ### Setup RStudio Project
+>
+> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
+>
+> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
+>
+{: .prereq}
+
 This tutorial explores how to import and plot a multi-band raster in
 R. It also covers how to plot a three-band color image using the `plotRGB()`
 function in `R`.

--- a/_episodes_rmd/06-vector-open-shapefile-in-r.Rmd
+++ b/_episodes_rmd/06-vector-open-shapefile-in-r.Rmd
@@ -18,6 +18,13 @@ source("../setup.R")
 knitr_fig_path("06-")
 ```
 
+```{r load-libraries, echo = FALSE}
+library(raster)
+library(rgdal)
+library(ggplot2)
+library(dplyr)
+```
+
 > ## Things You’ll Need To Complete This episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
@@ -45,15 +52,6 @@ stored in shapefile format in `R`.
 We will use the `sf` package to work with vector data in `R`. Notice that the
 `rgdal` package automatically loads when `sf` is loaded. We will also load the
 `raster` package so we can explore raster and vector spatial metadata using similar commands.
-
-```{r load-libraries }
-# load required libraries
-# for vector work
-library(sf)
-# for metadata/attributes- vectors or rasters
-library(raster)
-
-```
 
 The shapefiles that we will import are:
 

--- a/_episodes_rmd/06-vector-open-shapefile-in-r.Rmd
+++ b/_episodes_rmd/06-vector-open-shapefile-in-r.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Open and Plot Shapefiles in R"
-teaching: 10
-exercises: 0
+teaching: 20
+exercises: 10
 questions:
 - "Getting started with point, line and polygon vector data."
 objectives:
@@ -18,7 +18,7 @@ source("../setup.R")
 knitr_fig_path("06-")
 ```
 
-```{r load-libraries, echo = FALSE}
+```{r load-libraries, echo = FALSE, results='hide'}
 library(raster)
 library(rgdal)
 library(ggplot2)
@@ -26,22 +26,8 @@ library(dplyr)
 ```
 
 > ## Things You’ll Need To Complete This Episode
-> **R Skill Level:** Intermediate - you've got the basics of `R` down.
->
-> ### Install software
-> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
->
-> ### Download Data
->
-> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
-> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
->
-> ### Setup RStudio Project
->
-> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
->
-> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
->
+> See the [lesson homepage]({{ site.baseurl }}) for detailed information about the software,
+> data, and other prerequisites you will need to work through the examples in this episode.
 {: .prereq}
 
 In this episode, we will open and plot point, line and polygon vector data

--- a/_episodes_rmd/06-vector-open-shapefile-in-r.Rmd
+++ b/_episodes_rmd/06-vector-open-shapefile-in-r.Rmd
@@ -40,55 +40,6 @@ knitr_fig_path("06-")
 In this episode, we will open and plot point, line and polygon vector data
 stored in shapefile format in `R`.
 
-## About Vector Data
-Vector data are composed of discrete geometric locations (x, y values) known as
-**vertices** that define the "shape" of the spatial object. The organization
-of the vertices, determines the type of vector that we are working
-with: point, line or polygon.
-
-<figure>
-    <a href="{{ site.baseurl }}/images/dc-spatial-vector/pnt_line_poly.png">
-    <img src="{{ site.baseurl }}/images/dc-spatial-vector/pnt_line_poly.png"></a>
-    <figcaption> There are 3 types of vector objects: points, lines or
-    polygons. Each object type has a different structure.
-    Image Source: National Ecological Observatory Network (NEON)
-    </figcaption>
-</figure>
-
-* **Points:** Each individual point is defined by a single x, y coordinate.
-There can be many points in a vector point file. Examples of point data include:
-sampling locations, the location of individual trees or the location of plots.
-* **Lines:** Lines are composed of many (at least 2) vertices, or points, that
-are connected. For instance, a road or a stream may be represented by a line. This
-line is composed of a series of segments, each "bend" in the road or stream
-represents a vertex that has defined `x, y` location.
-* **Polygons:** A polygon consists of 3 or more vertices that are connected and
-"closed". Thus the outlines of plot boundaries, lakes, oceans, and states or
-countries are often represented by polygons. Occasionally, a polygon can have a
-hole in the middle of it (like a doughnut), this is something to be aware of but
-not an issue we will deal with in this episode.
-
-> ## Data Tip
-> Sometimes, boundary layers such as
->  states and countries, are stored as lines rather than polygons. However, these
-> boundaries, when represented as a line, will not create a closed object with a defined "area" that can be "filled".
-{: .callout}
-
-## Shapefiles: Points, Lines, and Polygons
-Geospatial data in vector format are often stored in a `shapefile` format.
-Because the structure of points, lines, and polygons are different, each
-individual shapefile can only contain one vector type (all points, all lines
-or all polygons). You will not find a mixture of point, line and polygon
-objects in a single shapefile.
-
-Objects stored in a shapefile often have a set of associated `attributes` that
-describe the data. For example, a line shapefile that contains the locations of
-streams, might contain the associated stream name, stream "order" and other
-information about each stream line object.
-
-* More about shapefiles can found on
-<a href="https://en.wikipedia.org/wiki/Shapefile" target="_blank">Wikipedia</a>.
-
 ## Import Shapefiles
 
 We will use the `sf` package to work with vector data in `R`. Notice that the

--- a/_episodes_rmd/06-vector-open-shapefile-in-r.Rmd
+++ b/_episodes_rmd/06-vector-open-shapefile-in-r.Rmd
@@ -286,10 +286,3 @@ plot(point_HARV, add  = TRUE, pch = 19, col = "purple")
 > > ```
 > {: .solution}
 {: .challenge}
-
-## Additional Resources: Plot Parameter Options
-For more on parameter options in the base `R` `plot()` function, check out these
-resources:
-
-* <a href="http://www.statmethods.net/advgraphs/parameters.html" target="_blank">Parameter methods in `R`.</a>
-* <a href="https://codeyarns.files.wordpress.com/2011/07/20110729-vim-named-colors.png?w=700" target="_blank">Color names in `R`</a>

--- a/_episodes_rmd/06-vector-open-shapefile-in-r.Rmd
+++ b/_episodes_rmd/06-vector-open-shapefile-in-r.Rmd
@@ -25,7 +25,7 @@ library(ggplot2)
 library(dplyr)
 ```
 
-> ## Things You’ll Need To Complete This episode
+> ## Things You’ll Need To Complete This Episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
 > ### Install software

--- a/_episodes_rmd/06-vector-open-shapefile-in-r.Rmd
+++ b/_episodes_rmd/06-vector-open-shapefile-in-r.Rmd
@@ -10,17 +10,6 @@ objectives:
 - "Understand the components of a spatial object in `R`."
 keypoints:
 - ""
-authors: [Joseph Stachelek, Leah A. Wasser, Megan A. Jones]
-contributors: [Sarah Newman]
-dateCreated:  2015-10-23
-lastModified: `r format(Sys.time(), "%Y-%m-%d")`
-packagesLibraries: [rgdal, raster]
-categories: [self-paced-tutorial]
-mainTag: vector-data-series
-tags: [vector-data, R, spatial-data-gis]
-tutorialSeries: [vector-data-series]
-description: "This spatial data tutorial explains the how to open and plot
-shapefiles containing point, line and polygon vector data in R."
 ---
 
 ```{r setup, echo=FALSE}
@@ -48,7 +37,7 @@ knitr_fig_path("06-")
 >
 {: .prereq}
 
-In this tutorial, we will open and plot point, line and polygon vector data
+In this episode, we will open and plot point, line and polygon vector data
 stored in shapefile format in `R`.
 
 ## About Vector Data
@@ -77,7 +66,7 @@ represents a vertex that has defined `x, y` location.
 "closed". Thus the outlines of plot boundaries, lakes, oceans, and states or
 countries are often represented by polygons. Occasionally, a polygon can have a
 hole in the middle of it (like a doughnut), this is something to be aware of but
-not an issue we will deal with in this tutorial.
+not an issue we will deal with in this episode.
 
 > ## Data Tip
 > Sometimes, boundary layers such as
@@ -149,7 +138,7 @@ with each individual vector object.
 
 > ## Data Tip
 > The [Shapefile Metadata & Attributes in R]({{site.baseurl}}/R/shapefile-attributes-in-R/)
-> tutorial provides more information on both metadata and attributes
+> episode provides more information on both metadata and attributes
 > and using attributes to subset and plot data.
 {: .callout}
 
@@ -338,7 +327,7 @@ plot(point_HARV, add  = TRUE, pch = 19, col = "purple")
 > For assistance consider using the
 > [Shapefile Metadata & Attributes in R]({{site.baseurl}}/R/shapefile-attributes-in-R/),
 > the [Plot Raster Data in R]({{site.baseurl}}/R/Plot-Rasters-In-R/ )
-> tutorials.
+> episodes.
 > 
 > > ## Answers
 > > 

--- a/_episodes_rmd/06-vector-open-shapefile-in-r.Rmd
+++ b/_episodes_rmd/06-vector-open-shapefile-in-r.Rmd
@@ -29,6 +29,25 @@ source("../setup.R")
 knitr_fig_path("06-")
 ```
 
+> ## Things You’ll Need To Complete This episode
+> **R Skill Level:** Intermediate - you've got the basics of `R` down.
+>
+> ### Install software
+> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
+>
+> ### Download Data
+>
+> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
+> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
+>
+> ### Setup RStudio Project
+>
+> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
+>
+> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
+>
+{: .prereq}
+
 In this tutorial, we will open and plot point, line and polygon vector data
 stored in shapefile format in `R`.
 

--- a/_episodes_rmd/07-vector-shapefile-attributes-in-r.Rmd
+++ b/_episodes_rmd/07-vector-shapefile-attributes-in-r.Rmd
@@ -19,6 +19,14 @@ source("../setup.R")
 knitr_fig_path("07-")
 ```
 
+```{r load-libraries, echo = FALSE}
+library(raster)
+library(rgdal)
+library(ggplot2)
+library(dplyr)
+```
+
+
 > ## Things You’ll Need To Complete This episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
@@ -63,13 +71,7 @@ If you completed the
 [Open and Plot Shapefiles in R]({{site.baseurl}}/R/open-shapefiles-in-R/)
 episode, you can skip this code.
 
-```{r load-packages-data }
-# load packages
-# sf: for vector work
-library(sf)
-# raster: for raster metadata/attributes
-library(raster)
-
+```
 # Import a polygon shapefile
 aoi_boundary_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HarClip_UTMZ18.shp")
 

--- a/_episodes_rmd/07-vector-shapefile-attributes-in-r.Rmd
+++ b/_episodes_rmd/07-vector-shapefile-attributes-in-r.Rmd
@@ -45,33 +45,19 @@ stores metadata and attributes associated with the file.
 ## Load the Data
 To work with vector data in `R`, we can use the `sf` package. The `raster`
 package also allows us to explore metadata using similar commands for both
-raster and vector files.
+raster and vector files. Make sure that you have these libraries loaded.
 
-We will import three shapefiles. The first is our `AOI` or area of
-interest boundary polygon that we worked with in
-[Open and Plot Shapefiles in R]({{site.baseurl}}/R/open-shapefiles-in-R/).
-The second is a shapefile containing the location of roads and trails within the
-field site. The third is a file containing the Fisher tower location.
-
-If you completed the
-[Open and Plot Shapefiles in R]({{site.baseurl}}/R/open-shapefiles-in-R/)
-episode, you can skip this code.
-
+```{r load-libraries-2, eval=FALSE}
+library(sf)
+library(raster)
 ```
-# Import a polygon shapefile
-aoi_boundary_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HarClip_UTMZ18.shp")
 
-# Import a line shapefile
-lines_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HARV_roads.shp")
-
-# Import a point shapefile
-point_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HARVtower_UTM18N.shp")
-
-```
+We will continue to work with the three shapefiles that we loaded in the
+[Open and Plot Shapefiles in R]({{site.baseurl}}/06-vector-open-shapefile-in-r/) episode.
 
 ## Query Shapefile Metadata
 Remember, as covered in
-[Open and Plot Shapefiles in R]({{site.baseurl}}/R/open-shapefiles-in-R/),
+[Open and Plot Shapefiles in R]({{site.baseurl}}/06-vector-open-shapefile-in-r/),
 we can view metadata associated with an `R` object using:
 
 * `st_geometry_type()` - Describes the type of vector data stored in the object.

--- a/_episodes_rmd/07-vector-shapefile-attributes-in-r.Rmd
+++ b/_episodes_rmd/07-vector-shapefile-attributes-in-r.Rmd
@@ -36,6 +36,25 @@ source("../setup.R")
 knitr_fig_path("07-")
 ```
 
+> ## Things You’ll Need To Complete This episode
+> **R Skill Level:** Intermediate - you've got the basics of `R` down.
+>
+> ### Install software
+> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
+>
+> ### Download Data
+>
+> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
+> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
+>
+> ### Setup RStudio Project
+>
+> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
+>
+> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
+>
+{: .prereq}
+
 This tutorial explains what shapefile attributes are and how to work with
 shapefile attributes in `R`. It also covers how to identify and query shapefile
 attributes, as well as subset shapefiles by specific attribute values.

--- a/_episodes_rmd/07-vector-shapefile-attributes-in-r.Rmd
+++ b/_episodes_rmd/07-vector-shapefile-attributes-in-r.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Explore and Plot by Shapefile Attributes"
-teaching: 10
-exercises: 0
+teaching: 20
+exercises: 10
 questions:
 - "How can I view the attributes of a spatial object?"
 objectives:
@@ -19,7 +19,7 @@ source("../setup.R")
 knitr_fig_path("07-")
 ```
 
-```{r load-libraries, echo = FALSE}
+```{r load-libraries, echo = FALSE, results='hide'}
 library(raster)
 library(rgdal)
 library(ggplot2)
@@ -28,22 +28,8 @@ library(dplyr)
 
 
 > ## Things You’ll Need To Complete This Episode
-> **R Skill Level:** Intermediate - you've got the basics of `R` down.
->
-> ### Install software
-> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
->
-> ### Download Data
->
-> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
-> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
->
-> ### Setup RStudio Project
->
-> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
->
-> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
->
+> See the [lesson homepage]({{ site.baseurl }}) for detailed information about the software,
+> data, and other prerequisites you will need to work through the examples in this episode.
 {: .prereq}
 
 This episode explains what shapefile attributes are and how to work with

--- a/_episodes_rmd/07-vector-shapefile-attributes-in-r.Rmd
+++ b/_episodes_rmd/07-vector-shapefile-attributes-in-r.Rmd
@@ -11,23 +11,6 @@ objectives:
 keypoints:
 - "Spatial objects in sf are similar to standard data frames except for a geometry list-column."
 authors: [Joseph Stachelek, Leah A. Wasser, Megan A. Jones]
-contributors: [Sarah Newman]
-dateCreated:  2015-10-23
-lastModified: `r format(Sys.time(), "%Y-%m-%d")`
-packagesLibraries: [rgdal, raster]
-categories: [self-paced-tutorial]
-mainTag: vector-data-series
-tags: [vector-data, R, spatial-data-gis]
-tutorialSeries: [vector-data-series]
-description: "This tutorial provides an overview of how to locate and query
-shapefile attributes as well as subset shapefiles by specific attribute values
-in R. It also covers plotting multiple shapefiles by attribute and building a
-custom plot legend. "
-image:
-  feature: NEONCarpentryHeader_2.png
-  credit: A collaboration between the National Ecological Observatory Network (NEON) and Data Carpentry
-  creditlink:
-comments: true
 ---
 
 ```{r setup, echo=FALSE}
@@ -55,7 +38,7 @@ knitr_fig_path("07-")
 >
 {: .prereq}
 
-This tutorial explains what shapefile attributes are and how to work with
+This episode explains what shapefile attributes are and how to work with
 shapefile attributes in `R`. It also covers how to identify and query shapefile
 attributes, as well as subset shapefiles by specific attribute values.
 Finally, we will review how to plot a shapefile according to a set of attribute
@@ -78,7 +61,7 @@ field site. The third is a file containing the Fisher tower location.
 
 If you completed the
 [Open and Plot Shapefiles in R]({{site.baseurl}}/R/open-shapefiles-in-R/)
-tutorial, you can skip this code.
+episode, you can skip this code.
 
 ```{r load-packages-data }
 # load packages

--- a/_episodes_rmd/07-vector-shapefile-attributes-in-r.Rmd
+++ b/_episodes_rmd/07-vector-shapefile-attributes-in-r.Rmd
@@ -27,7 +27,7 @@ library(dplyr)
 ```
 
 
-> ## Things You’ll Need To Complete This episode
+> ## Things You’ll Need To Complete This Episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
 > ### Install software

--- a/_episodes_rmd/08-vector-plot-shapefiles-custom-legend.Rmd
+++ b/_episodes_rmd/08-vector-plot-shapefiles-custom-legend.Rmd
@@ -35,6 +35,25 @@ source("../setup.R")
 knitr_fig_path("08-")
 ```
 
+> ## Things You’ll Need To Complete This episode
+> **R Skill Level:** Intermediate - you've got the basics of `R` down.
+>
+> ### Install software
+> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
+>
+> ### Download Data
+>
+> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
+> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
+>
+> ### Setup RStudio Project
+>
+> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
+>
+> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
+>
+{: .prereq}
+
 This tutorial builds upon
 [the previous tutorial]({{ site.baseurl }}/R/shapefile-attributes-in-R/)
 to work with shapefile attributes in `R` and explores how to plot multiple

--- a/_episodes_rmd/08-vector-plot-shapefiles-custom-legend.Rmd
+++ b/_episodes_rmd/08-vector-plot-shapefiles-custom-legend.Rmd
@@ -45,23 +45,18 @@ library(sf)
 library(raster)
 ```
 
-We will use three shapefiles in this lesson. The first is our `AOI` or *area of
-interest* boundary polygon that we worked with in the
+We will continue to work with the three shapefiles that we loaded in the
 [Open and Plot Shapefiles in R]({{site.baseurl}}/06-vector-open-shapefile-in-r/) episode.
-The second is a shapefile containing the location of roads and trails within the
-field site. The third is a file containing the Harvard Forest Fisher tower
-location. These latter two we worked with in the
-[Explore Shapefile Attributes & Plot Shapefile Objects by Attribute Value in R]({{site.baseurl}}/07-vector-shapefile-attributes-in-r/) episode.
 
-```{r load-data, echo = FALSE}
-# Import a polygon shapefile
+```{r load-data, echo = FALSE, results='hide', warning=FALSE}
 aoi_boundary_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HarClip_UTMZ18.shp")
 
-# Import a line shapefile
 lines_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HARV_roads.shp")
 
-# Import a point shapefile
 point_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HARVtower_UTM18N.shp")
+
+chm_HARV <-
+raster("data/NEON-DS-Airborne-Remote-Sensing/HARV/CHM/HARV_chmCrop.tif")
 ```
 
 ## Plot Data

--- a/_episodes_rmd/08-vector-plot-shapefiles-custom-legend.Rmd
+++ b/_episodes_rmd/08-vector-plot-shapefiles-custom-legend.Rmd
@@ -10,23 +10,6 @@ objectives:
 - "Be able to customize a baseplot legend in R."
 keypoints:
 - ""
-authors: [Joseph Stachelek, Leah A. Wasser, Megan A. Jones]
-contributors: [Sarah Newman]
-dateCreated:  2016-02-09
-lastModified: `r format(Sys.time(), "%Y-%m-%d")`
-packagesLibraries: [rgdal, raster]
-categories: [self-paced-tutorial]
-mainTag: vector-data-series
-tags: [vector-data, R, spatial-data-gis]
-tutorialSeries: [vector-data-series]
-description: "This tutorial provides an overview of how to create a a plot of
-multiple shapefiles using base R plot. It also explores adding a legend with
-custom symbols that match your plot colors and symbols."
-image:
-  feature: NEONCarpentryHeader_2.png
-  credit: A collaboration between the National Ecological Observatory Network (NEON) and Data Carpentry
-  creditlink:
-comments: true
 ---
 
 ```{r setup, echo=FALSE}
@@ -54,8 +37,8 @@ knitr_fig_path("08-")
 >
 {: .prereq}
 
-This tutorial builds upon
-[the previous tutorial]({{ site.baseurl }}/R/shapefile-attributes-in-R/)
+This episode builds upon
+[the previous episode]({{ site.baseurl }}/R/shapefile-attributes-in-R/)
 to work with shapefile attributes in `R` and explores how to plot multiple
 shapefiles using base R graphics. It then covers
 how to create a custom legend with colors and symbols that match your plot.
@@ -71,7 +54,7 @@ interest* boundary polygon that we worked with in
 The second is a shapefile containing the location of roads and trails within the
 field site. The third is a file containing the Harvard Forest Fisher tower
 location. These latter two we worked with in the
-[Explore Shapefile Attributes & Plot Shapefile Objects by Attribute Value in R]({{site.baseurl}}/R/shapefile-attributes-in-R/) tutorial.
+[Explore Shapefile Attributes & Plot Shapefile Objects by Attribute Value in R]({{site.baseurl}}/R/shapefile-attributes-in-R/) episode.
 
 ```{r load-packages-data }
 # load packages
@@ -91,7 +74,7 @@ point_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HARVtower_UTM18N.shp"
 ## Plot Data
 
 In the
-[*Explore Shapefile Attributes & Plot Shapefile Objects by Attribute Value in R* tutorial]({{ site.baseurl }}/R/shapefile-attributes-in-R/)
+[*Explore Shapefile Attributes & Plot Shapefile Objects by Attribute Value in R* episode]({{ site.baseurl }}/R/shapefile-attributes-in-R/)
 we created a plot where we customized the width of each line in a spatial object
 according to a factor level or category. To do this, we create a vector of
 colors containing a color value for EACH feature in our spatial object grouped
@@ -135,7 +118,7 @@ plot(lines_HARV$geometry,
 
 ## Add Plot Legend
 In the
-[previous tutorial]({{ site.baseurl }}/R/shapefile-attributes-in-R/),
+[previous episode]({{ site.baseurl }}/R/shapefile-attributes-in-R/),
 we also learned how to add a basic legend to our plot.
 
 * `bottomright`: We specify the **location** of our legend by using a default

--- a/_episodes_rmd/08-vector-plot-shapefiles-custom-legend.Rmd
+++ b/_episodes_rmd/08-vector-plot-shapefiles-custom-legend.Rmd
@@ -31,25 +31,29 @@ library(dplyr)
 {: .prereq}
 
 This episode builds upon
-[the previous episode]({{ site.baseurl }}/R/shapefile-attributes-in-R/)
+[the previous episode]({{ site.baseurl }}/07-vector-shapefile-attributes-in-r/)
 to work with shapefile attributes in `R` and explores how to plot multiple
-shapefiles using base R graphics. It then covers
-how to create a custom legend with colors and symbols that match your plot.
+shapefiles using base R graphics.
 
 ## Load the Data
 To work with vector data in `R`, we can use the `sf` library. The `raster`
 package also allows us to explore metadata using similar commands for both
-raster and vector files.
+raster and vector files. Make sure that you have these libraries loaded.
 
-We will import three shapefiles. The first is our `AOI` or *area of
-interest* boundary polygon that we worked with in
-[Open and Plot Shapefiles in R]({{site.baseurl}}/R/open-shapefiles-in-R/).
+```{r load-libraries-2, eval=FALSE}
+library(sf)
+library(raster)
+```
+
+We will use three shapefiles in this lesson. The first is our `AOI` or *area of
+interest* boundary polygon that we worked with in the
+[Open and Plot Shapefiles in R]({{site.baseurl}}/06-vector-open-shapefile-in-r/) episode.
 The second is a shapefile containing the location of roads and trails within the
 field site. The third is a file containing the Harvard Forest Fisher tower
 location. These latter two we worked with in the
-[Explore Shapefile Attributes & Plot Shapefile Objects by Attribute Value in R]({{site.baseurl}}/R/shapefile-attributes-in-R/) episode.
+[Explore Shapefile Attributes & Plot Shapefile Objects by Attribute Value in R]({{site.baseurl}}/07-vector-shapefile-attributes-in-r/) episode.
 
-```{r load-data }
+```{r load-data, echo = FALSE}
 # Import a polygon shapefile
 aoi_boundary_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HarClip_UTMZ18.shp")
 
@@ -63,7 +67,7 @@ point_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HARVtower_UTM18N.shp"
 ## Plot Data
 
 In the
-[*Explore Shapefile Attributes & Plot Shapefile Objects by Attribute Value in R* episode]({{ site.baseurl }}/R/shapefile-attributes-in-R/)
+[Explore Shapefile Attributes & Plot Shapefile Objects by Attribute Value in R]({{ site.baseurl }}/07-vector-shapefile-attributes-in-r/) episode,
 we created a plot where we customized the width of each line in a spatial object
 according to a factor level or category. To do this, we create a vector of
 colors containing a color value for EACH feature in our spatial object grouped

--- a/_episodes_rmd/08-vector-plot-shapefiles-custom-legend.Rmd
+++ b/_episodes_rmd/08-vector-plot-shapefiles-custom-legend.Rmd
@@ -18,6 +18,13 @@ source("../setup.R")
 knitr_fig_path("08-")
 ```
 
+```{r load-libraries, echo = FALSE}
+library(raster)
+library(rgdal)
+library(ggplot2)
+library(dplyr)
+```
+
 > ## Things You’ll Need To Complete This episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
@@ -56,11 +63,7 @@ field site. The third is a file containing the Harvard Forest Fisher tower
 location. These latter two we worked with in the
 [Explore Shapefile Attributes & Plot Shapefile Objects by Attribute Value in R]({{site.baseurl}}/R/shapefile-attributes-in-R/) episode.
 
-```{r load-packages-data }
-# load packages
-library(sf)
-library(raster)
-
+```{r load-data }
 # Import a polygon shapefile
 aoi_boundary_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HarClip_UTMZ18.shp")
 

--- a/_episodes_rmd/08-vector-plot-shapefiles-custom-legend.Rmd
+++ b/_episodes_rmd/08-vector-plot-shapefiles-custom-legend.Rmd
@@ -25,7 +25,7 @@ library(ggplot2)
 library(dplyr)
 ```
 
-> ## Things You’ll Need To Complete This episode
+> ## Things You’ll Need To Complete This Episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
 > ### Install software

--- a/_episodes_rmd/08-vector-plot-shapefiles-custom-legend.Rmd
+++ b/_episodes_rmd/08-vector-plot-shapefiles-custom-legend.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Plot Multiple Shapefiles in R"
-teaching: 10
-exercises: 0
+teaching: 20
+exercises: 10
 questions:
 - "How to create map compositions with custom legends in base plot."
 objectives:
@@ -18,7 +18,7 @@ source("../setup.R")
 knitr_fig_path("08-")
 ```
 
-```{r load-libraries, echo = FALSE}
+```{r load-libraries, echo = FALSE, results='hide'}
 library(raster)
 library(rgdal)
 library(ggplot2)
@@ -26,22 +26,8 @@ library(dplyr)
 ```
 
 > ## Things You’ll Need To Complete This Episode
-> **R Skill Level:** Intermediate - you've got the basics of `R` down.
->
-> ### Install software
-> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
->
-> ### Download Data
->
-> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
-> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
->
-> ### Setup RStudio Project
->
-> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
->
-> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
->
+> See the [lesson homepage]({{ site.baseurl }}) for detailed information about the software,
+> data, and other prerequisites you will need to work through the examples in this episode.
 {: .prereq}
 
 This episode builds upon

--- a/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
+++ b/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
@@ -25,7 +25,6 @@ library(ggplot2)
 library(dplyr)
 ```
 
-
 > ## Things You’ll Need To Complete This Episode
 > See the [lesson homepage]({{ site.baseurl }}) for detailed information about the software,
 > data, and other prerequisites you will need to work through the examples in this episode.
@@ -67,19 +66,13 @@ for that state.
     Source: opennews.org</figcaption>
 </figure>
 
-
-Check out this short video highlighting how map projections can make continents
-seems proportionally larger or smaller than they actually are!
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/KUF_Ckv8HbE" frameborder="0" allowfullscreen></iframe>
-
 In this episode we will learn how to identify and manage spatial data
 in different projections. We will learn how to `reproject` the data so that they
 are in the same projection to support plotting / mapping. Note that these skills
 are also required for any geoprocessing / spatial analysis. Data need to be in
 the same CRS to ensure accurate results.
 
-We will use the `sf` and `raster` packages in this Episode.
+We will use the `sf` and `raster` packages in this episode.
 
 ## Import US Boundaries - Census Data
 

--- a/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
+++ b/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
@@ -93,7 +93,7 @@ are in the same projection to support plotting / mapping. Note that these skills
 are also required for any geoprocessing / spatial analysis. Data need to be in
 the same CRS to ensure accurate results.
 
-We will use the `sf` and `raster` packages in this episode.
+We will use the `sf` and `raster` packages in this Episode.
 
 ## Import US Boundaries - Census Data
 

--- a/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
+++ b/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
@@ -32,6 +32,25 @@ source("../setup.R")
 knitr_fig_path("09-")
 ```
 
+> ## Things You’ll Need To Complete This episode
+> **R Skill Level:** Intermediate - you've got the basics of `R` down.
+>
+> ### Install software
+> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
+>
+> ### Download Data
+>
+> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
+> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
+>
+> ### Setup RStudio Project
+>
+> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
+>
+> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
+>
+{: .prereq}
+
 In this tutorial, we will create a base map of our study site using a United States
 state and country boundary accessed from the
 <a href="https://www.census.gov/geo/maps-data/data/cbf/cbf_state.html" target="_blank"> United States Census Bureau</a>.

--- a/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
+++ b/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
@@ -18,6 +18,14 @@ source("../setup.R")
 knitr_fig_path("09-")
 ```
 
+```{r load-libraries, echo = FALSE}
+library(raster)
+library(rgdal)
+library(ggplot2)
+library(dplyr)
+```
+
+
 > ## Things You’ll Need To Complete This episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
@@ -86,14 +94,6 @@ are also required for any geoprocessing / spatial analysis. Data need to be in
 the same CRS to ensure accurate results.
 
 We will use the `sf` and `raster` packages in this episode.
-
-```{r load-libraries}
-
-# load packages
-library(sf)  # for vector work
-library(raster)   # for raster metadata/attributes
-
-```
 
 ## Import US Boundaries - Census Data
 

--- a/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
+++ b/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
@@ -10,20 +10,6 @@ objectives:
 - "Be familiar with the `proj4` string format which is one format used used to store / reference the `CRS` of a spatial object."
 keypoints:
 - ""
-authors: [Joseph Stachelek, Leah Wasser, Megan A. Jones]
-contributors: [Sarah Newman]
-dateCreated:  2015-10-23
-lastModified: `r format(Sys.time(), "%Y-%m-%d")`
-packagesLibraries: [rgdal, raster]
-categories: [self-paced-tutorial]
-mainTag: vector-data-series
-tags: [vector-data, R, spatial-data-gis]
-tutorialSeries: [vector-data-series]
-description: "This tutorial will cover how to identify the CRS of a spatial
-vector object in R. It will also explore differences in units associated with
-different projections and how to reproject data using spTransform in R. Spatial
-data need to be in the same projection in order to successfully map and process
-them in non-gui tools such as R."
 ---
 
 ```{r setup, echo=FALSE}
@@ -51,7 +37,7 @@ knitr_fig_path("09-")
 >
 {: .prereq}
 
-In this tutorial, we will create a base map of our study site using a United States
+In this episode, we will create a base map of our study site using a United States
 state and country boundary accessed from the
 <a href="https://www.census.gov/geo/maps-data/data/cbf/cbf_state.html" target="_blank"> United States Census Bureau</a>.
 We will learn how to map vector data that are in different `CRS` and thus
@@ -93,13 +79,13 @@ seems proportionally larger or smaller than they actually are!
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/KUF_Ckv8HbE" frameborder="0" allowfullscreen></iframe>
 
-In this tutorial we will learn how to identify and manage spatial data
+In this episode we will learn how to identify and manage spatial data
 in different projections. We will learn how to `reproject` the data so that they
 are in the same projection to support plotting / mapping. Note that these skills
 are also required for any geoprocessing / spatial analysis. Data need to be in
 the same CRS to ensure accurate results.
 
-We will use the `sf` and `raster` packages in this tutorial.
+We will use the `sf` and `raster` packages in this episode.
 
 ```{r load-libraries}
 
@@ -113,7 +99,7 @@ library(raster)   # for raster metadata/attributes
 
 There are many good sources of boundary base layers that we can use to create a
 basemap. Some `R` packages even have these base layers built in to support quick
-and efficient mapping. In this tutorial, we will use boundary layers for the
+and efficient mapping. In this episode, we will use boundary layers for the
 United States, provided by the
 <a href="https://www.census.gov/geo/maps-data/data/cbf/cbf_state.html" target="_blank"> United States Census Bureau.</a>
 
@@ -126,7 +112,7 @@ We will use the `st_read()` function to import the
 `/US-Boundary-Layers/US-State-Boundaries-Census-2014` layer into `R`. This layer
 contains the boundaries of all continental states in the U.S. Please note that
 these data have been modified and reprojected from the original data downloaded
-from the Census website to support the learning goals of this tutorial.
+from the Census website to support the learning goals of this episode.
 
 ```{r read-csv }
 
@@ -270,7 +256,7 @@ often recorded in *Decimal Degrees*.
 > ## Data Tip
 > the last portion of each `proj4` string
 > is `+towgs84=0,0,0 `. This is a conversion factor that is used if a datum
-> conversion is required. We will not deal with datums in this tutorial series.
+> conversion is required. We will not deal with datums in this episode series.
 {: .callout}
 
 ## CRS Units - View Object Extent

--- a/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
+++ b/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Handling Spatial Projection & CRS in R"
-teaching: 10
-exercises: 0
+teaching: 20
+exercises: 10
 questions:
 - "What to do when vector data don't line up."
 objectives:
@@ -18,7 +18,7 @@ source("../setup.R")
 knitr_fig_path("09-")
 ```
 
-```{r load-libraries, echo = FALSE}
+```{r load-libraries, echo = FALSE, results='hide'}
 library(raster)
 library(rgdal)
 library(ggplot2)
@@ -26,23 +26,9 @@ library(dplyr)
 ```
 
 
-> ## Things You’ll Need To Complete This episode
-> **R Skill Level:** Intermediate - you've got the basics of `R` down.
->
-> ### Install software
-> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
->
-> ### Download Data
->
-> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
-> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
->
-> ### Setup RStudio Project
->
-> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
->
-> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
->
+> ## Things You’ll Need To Complete This Episode
+> See the [lesson homepage]({{ site.baseurl }}) for detailed information about the software,
+> data, and other prerequisites you will need to work through the examples in this episode.
 {: .prereq}
 
 In this episode, we will create a base map of our study site using a United States

--- a/_episodes_rmd/10-vector-csv-to-shapefile-in-r.Rmd
+++ b/_episodes_rmd/10-vector-csv-to-shapefile-in-r.Rmd
@@ -11,19 +11,6 @@ objectives:
 - "Be able to plot raster and vector data in the same plot to create a map."
 keypoints:
 - "It is important to know the projection (if any) of your point data prior to converting to a spatial object."
-authors: [Joseph Stachelek, Leah A. Wasser, Megan A. Jones]
-contributors: [Sarah Newman]
-dateCreated:  2015-10-23
-lastModified: `r format(Sys.time(), "%Y-%m-%d")`
-packagesLibraries: [rgdal, raster]
-categories: [self-paced-tutorial]
-mainTag: vector-data-series
-tags: [vector-data, R, spatial-data-gis]
-tutorialSeries: [vector-data-series]
-description: "This tutorial covers how to convert a .csv file that contains
-spatial coordinate information into a spatial object in R. We will then export
-the spatial object as a Shapefile for efficient import into R and other GUI GIS
-applications including QGIS and ArcGIS"
 ---
 
 ```{r setup, echo=FALSE}
@@ -51,7 +38,7 @@ knitr_fig_path("10-")
 >
 {: .prereq}
 
-This tutorial will review how to import spatial points stored in `.csv` (Comma Separated Value) format into `R` as an `sf` spatial object. We will also reproject data imported from a shapefile format, export this data as a shapefile as well as plot raster and vector data as layers in the same plot.
+This episode will review how to import spatial points stored in `.csv` (Comma Separated Value) format into `R` as an `sf` spatial object. We will also reproject data imported from a shapefile format, export this data as a shapefile as well as plot raster and vector data as layers in the same plot.
 
 ## Spatial Data in Text Format
 
@@ -71,7 +58,7 @@ convert it into an `sf` spatial object. The `sf` object allows us to store both 
 of each point and the associated attribute data - or columns describing each
 feature in the spatial object.
 
-We will use the `sf` and `raster` libraries in this tutorial.
+We will use the `sf` and `raster` libraries in this episode.
 
 ```{r load-libraries}
 
@@ -141,7 +128,7 @@ There are several ways to figure out the CRS of spatial data in text format.
 1. We can check the file **metadata** in hopes that the CRS was recorded in the
 data. For more information on metadata, check out the
 [Why Metadata Are Important: How to Work with Metadata in Text & EML Format]({{site.baseurl}}/R/why-metadata-are-important/)
-tutorial.
+episode.
 2. We can explore the file itself to see if CRS information is embedded in the
 file header or somewhere in the data columns.
 
@@ -245,8 +232,8 @@ a plot using `xlim` and `ylim`.
 
 Let's first create an `sf` object from the
 `NEON-DS-Site-Layout-Files/HarClip_UTMZ18` shapefile. (If you have completed
-Vector 00-02 tutorials in this
-[Introduction to Working with Vector Data in R]({{site.baseurl}}/tutorial-series/vector-data-series/)
+Vector 00-02 episodes in this
+[Introduction to Working with Vector Data in R]({{site.baseurl}}/episode-series/vector-data-series/)
 series, you can skip this code as you have already created this object.)
 
 ``` {r create-aoi-boundary}
@@ -373,7 +360,7 @@ legend("bottomright",
 > HINT: Refer to
 > [When Vector Data Don't Line Up - Handling Spatial Projection & CRS in R]({{site.baseurl}}/R/vector-data-reproject-crs-R/)
 > for more on working with geographic coordinate systems. You may want to "borrow"
-> the projection from the objects used in that tutorial!
+> the projection from the objects used in that episode!
 > 
 > > ## Answers
 > > 
@@ -457,7 +444,7 @@ legend("bottomright",
 > > # try again but this time specify the x and ylims
 > > # note: we could also write a function that would harvest the smallest and
 > > # largest
-> > # x and y values from an extent object. This is beyond the scope of this tutorial.
+> > # x and y values from an extent object. This is beyond the scope of this episode.
 > > plot(plot_locations_sp_HARV$geometry,
 > >      main = "NEON Harvard Forest Field Site\nVegetation & Phenology Plots",
 > >      pch=8,

--- a/_episodes_rmd/10-vector-csv-to-shapefile-in-r.Rmd
+++ b/_episodes_rmd/10-vector-csv-to-shapefile-in-r.Rmd
@@ -19,6 +19,14 @@ source("../setup.R")
 knitr_fig_path("10-")
 ```
 
+```{r load-libraries, echo = FALSE}
+library(raster)
+library(rgdal)
+library(ggplot2)
+library(dplyr)
+```
+
+
 > ## Things You’ll Need To Complete This episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
@@ -59,14 +67,6 @@ of each point and the associated attribute data - or columns describing each
 feature in the spatial object.
 
 We will use the `sf` and `raster` libraries in this episode.
-
-```{r load-libraries}
-
-# load packages
-library(sf)  # for vector work;
-library(raster)   # for  raster metadata/attributes
-
-```
 
 ## Import .csv
 To begin let's import `.csv` file that contains plot coordinate `x, y`

--- a/_episodes_rmd/10-vector-csv-to-shapefile-in-r.Rmd
+++ b/_episodes_rmd/10-vector-csv-to-shapefile-in-r.Rmd
@@ -32,6 +32,25 @@ source("../setup.R")
 knitr_fig_path("10-")
 ```
 
+> ## Things You’ll Need To Complete This episode
+> **R Skill Level:** Intermediate - you've got the basics of `R` down.
+>
+> ### Install software
+> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
+>
+> ### Download Data
+>
+> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
+> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
+>
+> ### Setup RStudio Project
+>
+> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
+>
+> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
+>
+{: .prereq}
+
 This tutorial will review how to import spatial points stored in `.csv` (Comma Separated Value) format into `R` as an `sf` spatial object. We will also reproject data imported from a shapefile format, export this data as a shapefile as well as plot raster and vector data as layers in the same plot.
 
 ## Spatial Data in Text Format

--- a/_episodes_rmd/10-vector-csv-to-shapefile-in-r.Rmd
+++ b/_episodes_rmd/10-vector-csv-to-shapefile-in-r.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Convert from .csv to a Shapefile in R"
-teaching: 10
-exercises: 0
+teaching: 20
+exercises: 10
 questions:
 - ""
 objectives:
@@ -19,7 +19,7 @@ source("../setup.R")
 knitr_fig_path("10-")
 ```
 
-```{r load-libraries, echo = FALSE}
+```{r load-libraries, echo = FALSE, results='hide'}
 library(raster)
 library(rgdal)
 library(ggplot2)
@@ -28,22 +28,8 @@ library(dplyr)
 
 
 > ## Things You’ll Need To Complete This Episode
-> **R Skill Level:** Intermediate - you've got the basics of `R` down.
->
-> ### Install software
-> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
->
-> ### Download Data
->
-> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
-> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
->
-> ### Setup RStudio Project
->
-> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
->
-> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
->
+> See the [lesson homepage]({{ site.baseurl }}) for detailed information about the software,
+> data, and other prerequisites you will need to work through the examples in this episode.
 {: .prereq}
 
 This episode will review how to import spatial points stored in `.csv` (Comma Separated Value) format into `R` as an `sf` spatial object. We will also reproject data imported from a shapefile format, export this data as a shapefile as well as plot raster and vector data as layers in the same plot.

--- a/_episodes_rmd/10-vector-csv-to-shapefile-in-r.Rmd
+++ b/_episodes_rmd/10-vector-csv-to-shapefile-in-r.Rmd
@@ -27,7 +27,7 @@ library(dplyr)
 ```
 
 
-> ## Things You’ll Need To Complete This episode
+> ## Things You’ll Need To Complete This Episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
 > ### Install software

--- a/_episodes_rmd/11-vector-raster-integration.Rmd
+++ b/_episodes_rmd/11-vector-raster-integration.Rmd
@@ -24,7 +24,7 @@ library(ggplot2)
 library(dplyr)
 ```
 
-> ## Things You’ll Need To Complete This episode
+> ## Things You’ll Need To Complete This Episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
 > ### Install software

--- a/_episodes_rmd/11-vector-raster-integration.Rmd
+++ b/_episodes_rmd/11-vector-raster-integration.Rmd
@@ -17,6 +17,13 @@ source("../setup.R")
 knitr_fig_path("11-")
 ```
 
+```{r load-libraries, echo = FALSE}
+library(raster)
+library(rgdal)
+library(ggplot2)
+library(dplyr)
+```
+
 > ## Things You’ll Need To Complete This episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
@@ -66,10 +73,6 @@ and a raster file, that we will introduce this episode:
 * A canopy height model (CHM) in GeoTIFF format -- green
 
 ```{r view-extents, echo=FALSE}
-## Load Packages
-library(sf)
-library(raster)
-
 # Import a polygon shapefile
 aoi_boundary_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HarClip_UTMZ18.shp")
 

--- a/_episodes_rmd/11-vector-raster-integration.Rmd
+++ b/_episodes_rmd/11-vector-raster-integration.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Manipulate Raster Data in R"
-teaching: 10
-exercises: 0
+teaching: 20
+exercises: 10
 questions:
 - "How to crop raster layers and extract summary pixels."
 objectives:
@@ -17,7 +17,7 @@ source("../setup.R")
 knitr_fig_path("11-")
 ```
 
-```{r load-libraries, echo = FALSE}
+```{r load-libraries, echo = FALSE, results='hide'}
 library(raster)
 library(rgdal)
 library(ggplot2)
@@ -25,22 +25,8 @@ library(dplyr)
 ```
 
 > ## Things You’ll Need To Complete This Episode
-> **R Skill Level:** Intermediate - you've got the basics of `R` down.
->
-> ### Install software
-> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
->
-> ### Download Data
->
-> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
-> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
->
-> ### Setup RStudio Project
->
-> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
->
-> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
->
+> See the [lesson homepage]({{ site.baseurl }}) for detailed information about the software,
+> data, and other prerequisites you will need to work through the examples in this episode.
 {: .prereq}
 
 This episode explains how to crop a raster using the extent of a vector

--- a/_episodes_rmd/11-vector-raster-integration.Rmd
+++ b/_episodes_rmd/11-vector-raster-integration.Rmd
@@ -9,18 +9,6 @@ objectives:
 - "Be able to extract values from raster that correspond to a vector file overlay."
 keypoints:
 - ""
-authors: [Joseph Stachelek, Leah A. Wasser, Megan A. Jones]
-contributors: [Sarah Newman]
-dateCreated:  2015-10-23
-lastModified: `r format(Sys.time(), "%Y-%m-%d")`
-packagesLibraries: [rgdal, raster]
-categories: [self-paced-tutorial]
-mainTag: vector-data-series
-tags: [vector-data, R, spatial-data-gis]
-tutorialSeries: [vector-data-series]
-description: "This tutorial covers how to modify (crop) a raster extent using
-the extent of a vector shapefile. It also covers extracting pixel values from
-defined locations stored in a spatial object."
 ---
 
 ```{r setup, echo=FALSE}
@@ -48,7 +36,7 @@ knitr_fig_path("11-")
 >
 {: .prereq}
 
-This tutorial explains how to crop a raster using the extent of a vector
+This episode explains how to crop a raster using the extent of a vector
 shapefile. We will also cover how to extract values from a raster that occur
 within a set of polygons, or in a buffer (surrounding) region around a set of
 points.
@@ -67,13 +55,13 @@ We often work with spatial layers that have different spatial extents.
 </figure>
 
 The graphic below illustrates the extent of several of the spatial layers that
-we have worked with in this vector data tutorial series:
+we have worked with in this vector data episode series:
 
 * Area of interest (AOI) -- blue
 * Roads and trails -- purple
 * Vegetation plot locations -- black
 
-and a raster file, that we will introduce this tutorial:
+and a raster file, that we will introduce this episode:
 
 * A canopy height model (CHM) in GeoTIFF format -- green
 
@@ -157,8 +145,8 @@ roads/trails, tower location, and veg study plot locations) and one raster
 GeoTIFF file, a Canopy Height Model for the Harvard Forest, Massachusetts.
 These data can be used to create maps that characterize our study location.
 
-If you have completed the Vector 00-04 tutorials in this
-[Introduction to Working with Vector Data in R]({{site.baseurl}}/tutorial-series/vector-data-series/)
+If you have completed the Vector 00-04 episodes in this
+[Introduction to Working with Vector Data in R]({{site.baseurl}}/episode-series/vector-data-series/)
 series, you can skip this code as you have already created these object.)
 
 ```{r load-libraries-data, results="hide", warning=FALSE }
@@ -270,7 +258,7 @@ In the plot above, created in the challenge, all the vegetation plot locations
 (blue) appear on the Canopy Height Model raster layer except for one. One is
 situated on the white space. Why?
 
-A modification of the first figure in this tutorial is below, showing the
+A modification of the first figure in this episode is below, showing the
 relative extents of all the spatial objects. Notice that the extent for our
 vegetation plot layer (black) extends further west than the extent of our CHM
 raster (bright green). The crop function will make a raster extent smaller, it

--- a/_episodes_rmd/11-vector-raster-integration.Rmd
+++ b/_episodes_rmd/11-vector-raster-integration.Rmd
@@ -48,7 +48,7 @@ We often work with spatial layers that have different spatial extents.
 </figure>
 
 The graphic below illustrates the extent of several of the spatial layers that
-we have worked with in this vector data episode series:
+we have worked with in this vector data series:
 
 * Area of interest (AOI) -- blue
 * Roads and trails -- purple
@@ -59,15 +59,6 @@ and a raster file, that we will introduce this episode:
 * A canopy height model (CHM) in GeoTIFF format -- green
 
 ```{r view-extents, echo=FALSE}
-# Import a polygon shapefile
-aoi_boundary_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HarClip_UTMZ18.shp")
-
-# Import a line shapefile
-lines_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HARV_roads.shp")
-
-# Import a point shapefile
-point_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HARVtower_UTM18N.shp")
-
 chm_HARV <- raster("data/NEON-DS-Airborne-Remote-Sensing/HARV/CHM/HARV_chmCrop.tif")
 
 utm18nCRS <- st_crs(point_HARV)
@@ -128,34 +119,15 @@ study area to keep reduce file sizes as we process our data.
 Cropping a raster can also be useful when creating pretty maps so that the
 raster layer matches the extent of the desired vector layers.
 
-### Import Data
-We will begin by importing four vector shapefiles (field site boundary,
-roads/trails, tower location, and veg study plot locations) and one raster
-GeoTIFF file, a Canopy Height Model for the Harvard Forest, Massachusetts.
-These data can be used to create maps that characterize our study location.
-
-If you have completed the Vector 00-04 episodes in this
-[Introduction to Working with Vector Data in R]({{site.baseurl}}/episode-series/vector-data-series/)
-series, you can skip this code as you have already created these object.)
-
-```{r load-libraries-data, results="hide", warning=FALSE }
-# load necessary packages
-library(sf)
-library(raster)
-
-# Imported in Vector 00: Vector Data in R - Open & Plot Data
-# shapefile
+```{r load-data, echo = FALSE, results='hide', warning=FALSE}
 aoi_boundary_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HarClip_UTMZ18.shp")
-# Import a line shapefile
+
 lines_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HARV_roads.shp")
-# Import a point shapefile
+
 point_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HARVtower_UTM18N.shp")
 
-# Imported in  Vector 02: .csv to Shapefile in R
-# import raster Canopy Height Model (CHM)
 chm_HARV <-
   raster("data/NEON-DS-Airborne-Remote-Sensing/HARV/CHM/HARV_chmCrop.tif")
-
 ```
 
 ## Crop a Raster Using Vector Extent

--- a/_episodes_rmd/11-vector-raster-integration.Rmd
+++ b/_episodes_rmd/11-vector-raster-integration.Rmd
@@ -29,6 +29,25 @@ source("../setup.R")
 knitr_fig_path("11-")
 ```
 
+> ## Things You’ll Need To Complete This episode
+> **R Skill Level:** Intermediate - you've got the basics of `R` down.
+>
+> ### Install software
+> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
+>
+> ### Download Data
+>
+> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
+> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
+>
+> ### Setup RStudio Project
+>
+> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
+>
+> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
+>
+{: .prereq}
+
 This tutorial explains how to crop a raster using the extent of a vector
 shapefile. We will also cover how to extract values from a raster that occur
 within a set of polygons, or in a buffer (surrounding) region around a set of

--- a/_episodes_rmd/12-time-series-raster.Rmd
+++ b/_episodes_rmd/12-time-series-raster.Rmd
@@ -36,6 +36,25 @@ source("../setup.R")
 knitr_fig_path("12-")
 ```
 
+> ## Things You’ll Need To Complete This episode
+> **R Skill Level:** Intermediate - you've got the basics of `R` down.
+>
+> ### Install software
+> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
+>
+> ### Download Data
+>
+> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
+> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
+>
+> ### Setup RStudio Project
+>
+> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
+>
+> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
+>
+{: .prereq}
+
 This tutorial covers how to work with and plot a raster time series, using an
 `R` `RasterStack` object. It also covers practical assessment of data quality in
 remote sensing derived imagery.

--- a/_episodes_rmd/12-time-series-raster.Rmd
+++ b/_episodes_rmd/12-time-series-raster.Rmd
@@ -19,6 +19,14 @@ source("../setup.R")
 knitr_fig_path("12-")
 ```
 
+```{r load-libraries, echo = FALSE}
+library(raster)
+library(rgdal)
+library(ggplot2)
+library(dplyr)
+```
+
+
 > ## Things You’ll Need To Complete This episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
@@ -114,13 +122,6 @@ period that NDVI is available.
 
 ### Getting Started
 In this episode, we will use the `raster` and `rgdal` libraries.
-
-```{r load-libraries }
-# load packages
-library(raster)
-library(rgdal)
-
-```
 
 To begin, we will create a list of raster files using the `list.files()`
 function in `R`. This list will be used to generate a `RasterStack`. We will

--- a/_episodes_rmd/12-time-series-raster.Rmd
+++ b/_episodes_rmd/12-time-series-raster.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Raster Time Series Data in R"
-teaching: 10
-exercises: 0
+teaching: 20
+exercises: 10
 questions:
 - ""
 objectives:
@@ -19,7 +19,7 @@ source("../setup.R")
 knitr_fig_path("12-")
 ```
 
-```{r load-libraries, echo = FALSE}
+```{r load-libraries, echo = FALSE, results='hide'}
 library(raster)
 library(rgdal)
 library(ggplot2)
@@ -28,22 +28,8 @@ library(dplyr)
 
 
 > ## Things You’ll Need To Complete This Episode
-> **R Skill Level:** Intermediate - you've got the basics of `R` down.
->
-> ### Install software
-> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
->
-> ### Download Data
->
-> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
-> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
->
-> ### Setup RStudio Project
->
-> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
->
-> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
->
+> See the [lesson homepage]({{ site.baseurl }}) for detailed information about the software,
+> data, and other prerequisites you will need to work through the examples in this episode.
 {: .prereq}
 
 This episode covers how to work with and plot a raster time series, using an

--- a/_episodes_rmd/12-time-series-raster.Rmd
+++ b/_episodes_rmd/12-time-series-raster.Rmd
@@ -27,7 +27,7 @@ library(dplyr)
 ```
 
 
-> ## Things You’ll Need To Complete This episode
+> ## Things You’ll Need To Complete This Episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
 > ### Install software

--- a/_episodes_rmd/12-time-series-raster.Rmd
+++ b/_episodes_rmd/12-time-series-raster.Rmd
@@ -107,7 +107,7 @@ period that NDVI is available.
 </figure>
 
 ### Getting Started
-In this episode, we will use the `raster` and `rgdal` libraries.
+In this episode, we will use the `raster` and `rgdal` libraries. Make sure you have
 
 To begin, we will create a list of raster files using the `list.files()`
 function in `R`. This list will be used to generate a `RasterStack`. We will
@@ -239,7 +239,7 @@ quickly apply this factor using raster math on the entire stack as follows:
 > We can make this plot
 > even prettier by fixing the individual tile names, adding an plot title and by
 > using the (`levelplot`) function. This is covered in the NEON Data Skills
-> [Plot Time Series Rasters in R ]({{ site.baseurl }}/R/Plot-Raster-Times-Series-Data-In-R/)
+> [Plot Time Series Rasters in R ]({{ site.baseurl }}/13-plot-time-series-rasters-in-r/)
 > episode.
 {: .callout}
 

--- a/_episodes_rmd/12-time-series-raster.Rmd
+++ b/_episodes_rmd/12-time-series-raster.Rmd
@@ -11,23 +11,6 @@ objectives:
 - "Be able to plot and explore time series raster data using the `plot()` function in `R`."
 keypoints:
 - ""
-authors: [Leah A. Wasser, Megan A. Jones, Zack Brym, Kristina Riemer, Jason Williams, Jeff Hollister,  Mike Smorul, Joseph Stachelek]
-contributors: [ ]
-packagesLibraries: [raster, rgdal]
-dateCreated:  2014-11-26
-lastModified: `r format(Sys.time(), "%Y-%m-%d")`
-categories:  [self-paced-tutorial]
-tags: [R, raster, spatial-data-gis]
-tutorialSeries: [raster-data-series, raster-time-series]
-mainTag: raster-data-series
-description: "This tutorial covers how to work with and plot a raster time
-series, using an R RasterStack object. It also covers the basics of practical
-data quality assessment of remote sensing imagery."
-image:
-  feature: NEONCarpentryHeader_2.png
-  credit: A collaboration between the National Ecological Observatory Network (NEON) and Data Carpentry
-  creditlink:
-comments: true
 ---
 
 ```{r setup, echo=FALSE}
@@ -55,7 +38,7 @@ knitr_fig_path("12-")
 >
 {: .prereq}
 
-This tutorial covers how to work with and plot a raster time series, using an
+This episode covers how to work with and plot a raster time series, using an
 `R` `RasterStack` object. It also covers practical assessment of data quality in
 remote sensing derived imagery.
 
@@ -77,11 +60,11 @@ same **resolution**.
     </figcaption>
 </figure>
 
-The raster data that we will use in this tutorial are located in the
+The raster data that we will use in this episode are located in the
 (`NEON-DS-Landsat-NDVI\HARV\2011\NDVI`) directory and cover part of the
 <a href="http://www.neonscience.org/science-design/field-sites/harvard-forest" target="_blank">NEON Harvard Forest field site</a>.
 
-In this tutorial, we will:
+In this episode, we will:
 
 1. Import NDVI data in `GeoTIFF` format.
 2. Import, explore and plot NDVI data derived for several dates throughout the
@@ -130,7 +113,7 @@ period that NDVI is available.
 </figure>
 
 ### Getting Started
-In this tutorial, we will use the `raster` and `rgdal` libraries.
+In this episode, we will use the `raster` and `rgdal` libraries.
 
 ```{r load-libraries }
 # load packages
@@ -193,9 +176,9 @@ xres(NDVI_HARV_stack)
 ```
 
 Notice that the CRS is `+proj=utm +zone=19 +ellps=WGS84 +units=m +no_defs`. The
-CRS is in UTM Zone 19.  If you have completed the previous tutorials in
+CRS is in UTM Zone 19.  If you have completed the previous episodes in
 this
-[raster data in `R` series ]({{ site.baseurl }}tutorial-series/raster-data-series/),
+[raster data in `R` series ]({{ site.baseurl }}episode-series/raster-data-series/),
 you may have noticed that the UTM zone for the NEON collected remote sensing
 data was in Zone 18 rather than Zone 19. Why are the Landsat data in Zone 19?
 
@@ -270,7 +253,7 @@ quickly apply this factor using raster math on the entire stack as follows:
 > even prettier by fixing the individual tile names, adding an plot title and by
 > using the (`levelplot`) function. This is covered in the NEON Data Skills
 > [Plot Time Series Rasters in R ]({{ site.baseurl }}/R/Plot-Raster-Times-Series-Data-In-R/)
-> tutorial.
+> episode.
 {: .callout}
 
 ```{r apply-scale-factor }
@@ -297,7 +280,7 @@ Hint: the number after the "X" in each tile title is the Julian day which in
 this case represents the number of days into each year. If you are unfamiliar
 with Julian day, check out the NEON Data Skills
 [Converting to Julian Day ]({{ site.baseurl }}/R/julian-day-conversion/)
-tutorial.
+episode.
 
 ## View Distribution of Raster Values
 In the above exercise, we viewed plots of our NDVI time series and noticed a

--- a/_episodes_rmd/13-plot-time-series-rasters-in-r.Rmd
+++ b/_episodes_rmd/13-plot-time-series-rasters-in-r.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Plot Raster Time Series Data in R"
-teaching: 10
-exercises: 0
+teaching: 20
+exercises: 10
 questions:
 - ""
 objectives:
@@ -17,7 +17,7 @@ source("../setup.R")
 knitr_fig_path("13-")
 ```
 
-```{r load-libraries, echo = FALSE}
+```{r load-libraries, echo = FALSE, results='hide'}
 library(raster)
 library(rgdal)
 library(ggplot2)
@@ -26,22 +26,8 @@ library(dplyr)
 
 
 > ## Things You’ll Need To Complete This Episode
-> **R Skill Level:** Intermediate - you've got the basics of `R` down.
->
-> ### Install software
-> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
->
-> ### Download Data
->
-> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
-> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
->
-> ### Setup RStudio Project
->
-> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
->
-> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
->
+> See the [lesson homepage]({{ site.baseurl }}) for detailed information about the software,
+> data, and other prerequisites you will need to work through the examples in this episode.
 {: .prereq}
 
 This episode covers how to improve plotting output using the `rasterVis` package

--- a/_episodes_rmd/13-plot-time-series-rasters-in-r.Rmd
+++ b/_episodes_rmd/13-plot-time-series-rasters-in-r.Rmd
@@ -17,6 +17,14 @@ source("../setup.R")
 knitr_fig_path("13-")
 ```
 
+```{r load-libraries, echo = FALSE}
+library(raster)
+library(rgdal)
+library(ggplot2)
+library(dplyr)
+```
+
+
 > ## Things You’ll Need To Complete This episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
@@ -51,11 +59,7 @@ If you have not already created the RasterStack, originally created in
 [Raster Time Series Data in R ]({{ site.baseurl }}/R/Raster-Times-Series-Data-In-R/),
 please create it now.
 
-```{r load-libraries-data }
-
-library(raster)
-library(rgdal)
-library(rasterVis)
+```{r load-data }
 
 # Create list of NDVI file paths
 all_NDVI_HARV <- list.files("data/NEON-DS-Landsat-NDVI/HARV/2011/NDVI", full.names = TRUE, pattern = ".tif$")

--- a/_episodes_rmd/13-plot-time-series-rasters-in-r.Rmd
+++ b/_episodes_rmd/13-plot-time-series-rasters-in-r.Rmd
@@ -34,6 +34,25 @@ source("../setup.R")
 knitr_fig_path("13-")
 ```
 
+> ## Things You’ll Need To Complete This episode
+> **R Skill Level:** Intermediate - you've got the basics of `R` down.
+>
+> ### Install software
+> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
+>
+> ### Download Data
+>
+> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
+> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
+>
+> ### Setup RStudio Project
+>
+> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
+>
+> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
+>
+{: .prereq}
+
 This tutorial covers how to improve plotting output using the `rasterVis` package
 in `R`. Specifically it covers using `levelplot()` and adding meaningful custom
 names to bands within a `RasterStack`.

--- a/_episodes_rmd/13-plot-time-series-rasters-in-r.Rmd
+++ b/_episodes_rmd/13-plot-time-series-rasters-in-r.Rmd
@@ -34,18 +34,7 @@ This episode covers how to improve plotting output using the `rasterVis` package
 in `R`. Specifically it covers using `levelplot()` and adding meaningful custom
 names to bands within a `RasterStack`.
 
-## Get Started
-In this episode, we are working with the same set of rasters used in the
-[Raster Time Series Data in R ]({{ site.baseurl }}/R/Raster-Times-Series-Data-In-R/)
-episode. This data is derived from the Landsat satellite and stored in
-`GeoTIFF` format. Each raster covers the
-<a href="http://www.neonscience.org/science-design/field-sites/harvard-forest" target="_blank">NEON Harvard Forest field site</a>.
-
-If you have not already created the RasterStack, originally created in
-[Raster Time Series Data in R ]({{ site.baseurl }}/R/Raster-Times-Series-Data-In-R/),
-please create it now.
-
-```{r load-data }
+```{r load-data, echo = FALSE, results = 'hide'}
 
 # Create list of NDVI file paths
 all_NDVI_HARV <- list.files("data/NEON-DS-Landsat-NDVI/HARV/2011/NDVI", full.names = TRUE, pattern = ".tif$")

--- a/_episodes_rmd/13-plot-time-series-rasters-in-r.Rmd
+++ b/_episodes_rmd/13-plot-time-series-rasters-in-r.Rmd
@@ -9,23 +9,6 @@ objectives:
 - "Understand advanced plotting of rasters using the `rasterVis` package and `levelplot`."
 keypoints:
 - ""
-authors: [Leah A. Wasser, Megan A. Jones, Zack Brym, Kristina Riemer, Jason Williams, Jeff Hollister,  Mike Smorul, Joseph Stachelek]
-contributors: [ ]
-packagesLibraries: [raster, rgdal, rasterVis]
-dateCreated:  2014-11-26
-lastModified: `r format(Sys.time(), "%Y-%m-%d")`
-categories:  [self-paced-tutorial]
-tags: [R, raster, spatial-data-gis]
-mainTag: raster-data-series
-tutorialSeries: [raster-data-series, raster-time-series]
-description: "This tutorial covers how to efficiently and effectively plot a
-stack of rasters using rasterVis package in R. Specifically it covers using
-levelplot and adding meaningful, custom names to band labels in a RasterStack."
-image:
-  feature: NEONCarpentryHeader_2.png
-  credit: A collaboration between the National Ecological Observatory Network (NEON) and Data Carpentry
-  creditlink:
-comments: true
 ---
 
 ```{r setup, echo=FALSE}
@@ -53,14 +36,14 @@ knitr_fig_path("13-")
 >
 {: .prereq}
 
-This tutorial covers how to improve plotting output using the `rasterVis` package
+This episode covers how to improve plotting output using the `rasterVis` package
 in `R`. Specifically it covers using `levelplot()` and adding meaningful custom
 names to bands within a `RasterStack`.
 
 ## Get Started
-In this tutorial, we are working with the same set of rasters used in the
+In this episode, we are working with the same set of rasters used in the
 [Raster Time Series Data in R ]({{ site.baseurl }}/R/Raster-Times-Series-Data-In-R/)
-tutorial. This data is derived from the Landsat satellite and stored in
+episode. This data is derived from the Landsat satellite and stored in
 `GeoTIFF` format. Each raster covers the
 <a href="http://www.neonscience.org/science-design/field-sites/harvard-forest" target="_blank">NEON Harvard Forest field site</a>.
 

--- a/_episodes_rmd/13-plot-time-series-rasters-in-r.Rmd
+++ b/_episodes_rmd/13-plot-time-series-rasters-in-r.Rmd
@@ -25,7 +25,7 @@ library(dplyr)
 ```
 
 
-> ## Things You’ll Need To Complete This episode
+> ## Things You’ll Need To Complete This Episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
 > ### Install software

--- a/_episodes_rmd/14-extract-ndvi-from-rasters-in-r.Rmd
+++ b/_episodes_rmd/14-extract-ndvi-from-rasters-in-r.Rmd
@@ -19,6 +19,13 @@ source("../setup.R")
 knitr_fig_path("14-")
 ```
 
+```{r load-libraries, echo = FALSE}
+library(raster)
+library(rgdal)
+library(ggplot2)
+library(dplyr)
+```
+
 > ## Things You’ll Need To Complete This episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
@@ -56,11 +63,7 @@ and
 episodes. To begin, we will create a raster stack (also created in the previous
 episodes so you may be able to skip this first step!).
 
-```{r load-libraries-data }
-
-library(raster)
-library(rgdal)
-library(ggplot2)
+```{r load-data }
 
 # Create list of NDVI file paths
 all_HARV_NDVI <- list.files("data/NEON-DS-Landsat-NDVI/HARV/2011/NDVI",

--- a/_episodes_rmd/14-extract-ndvi-from-rasters-in-r.Rmd
+++ b/_episodes_rmd/14-extract-ndvi-from-rasters-in-r.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Derive Values from Raster Time Series"
-teaching: 10
-exercises: 0
+teaching: 20
+exercises: 10
 questions:
 - ""
 objectives:
@@ -19,7 +19,7 @@ source("../setup.R")
 knitr_fig_path("14-")
 ```
 
-```{r load-libraries, echo = FALSE}
+```{r load-libraries, echo = FALSE, results='hide'}
 library(raster)
 library(rgdal)
 library(ggplot2)
@@ -27,22 +27,8 @@ library(dplyr)
 ```
 
 > ## Things You’ll Need To Complete This Episode
-> **R Skill Level:** Intermediate - you've got the basics of `R` down.
->
-> ### Install software
-> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
->
-> ### Download Data
->
-> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
-> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
->
-> ### Setup RStudio Project
->
-> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
->
-> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
->
+> See the [lesson homepage]({{ site.baseurl }}) for detailed information about the software,
+> data, and other prerequisites you will need to work through the examples in this episode.
 {: .prereq}
 
 In this episode, we will extract NDVI values from a raster time series dataset

--- a/_episodes_rmd/14-extract-ndvi-from-rasters-in-r.Rmd
+++ b/_episodes_rmd/14-extract-ndvi-from-rasters-in-r.Rmd
@@ -41,15 +41,7 @@ each plot within a field site. These values can then be compared betweeen
 different field sites and combined with other
 related metrics to support modeling and further analysis.
 
-## Get Started
-In this episode, we will work with the same set of rasters used in the
-[Raster Time Series Data in R ]({{ site.baseurl }}/R/Raster-Times-Series-Data-In-R/)
-and
-[Plot Raster Time Series Data in R Using RasterVis and Levelplot ]({{ site.baseurl }}/R/Plot-Raster-Times-Series-Data-In-R/)
-episodes. To begin, we will create a raster stack (also created in the previous
-episodes so you may be able to skip this first step!).
-
-```{r load-data }
+```{r load-data, echo = FALSE, results = 'hide'}
 
 # Create list of NDVI file paths
 all_HARV_NDVI <- list.files("data/NEON-DS-Landsat-NDVI/HARV/2011/NDVI",

--- a/_episodes_rmd/14-extract-ndvi-from-rasters-in-r.Rmd
+++ b/_episodes_rmd/14-extract-ndvi-from-rasters-in-r.Rmd
@@ -11,22 +11,6 @@ objectives:
 - "Have experience comparing NDVI values between two different sites."
 keypoints:
 - ""
-authors: [Leah A. Wasser, Megan A. Jones, Zack Brym, Kristina Riemer, Jason Williams, Jeff Hollister, Mike Smorul, Joseph Stachelek]
-contributors: [ ]
-packagesLibraries: [raster, rgdal, ggplot2]
-dateCreated: 2014-11-26
-lastModified: `r format(Sys.time(), "%Y-%m-%d")`
-categories:  [self-paced-tutorial]
-tags: [R, raster, spatial-data-gis]
-mainTag: raster-data-series
-tutorialSeries: [raster-data-series, raster-time-series]
-description: "This tutorial covers how to extract and plot NDVI pixel values
-from a raster time series stack in R. We will use ggplot2 to plot our data."
-image:
-  feature: NEONCarpentryHeader_2.png
-  credit: A collaboration between the National Ecological Observatory Network (NEON) and Data Carpentry
-  creditlink:
-comments: true
 ---
 
 ```{r setup, echo=FALSE}
@@ -54,7 +38,7 @@ knitr_fig_path("14-")
 >
 {: .prereq}
 
-In this tutorial, we will extract NDVI values from a raster time series dataset
+In this episode, we will extract NDVI values from a raster time series dataset
 in `R` and plot them using `ggplot`.
 
 ## Extract Summary Statistics From Raster Data
@@ -65,12 +49,12 @@ different field sites and combined with other
 related metrics to support modeling and further analysis.
 
 ## Get Started
-In this tutorial, we will work with the same set of rasters used in the
+In this episode, we will work with the same set of rasters used in the
 [Raster Time Series Data in R ]({{ site.baseurl }}/R/Raster-Times-Series-Data-In-R/)
 and
 [Plot Raster Time Series Data in R Using RasterVis and Levelplot ]({{ site.baseurl }}/R/Plot-Raster-Times-Series-Data-In-R/)
-tutorials. To begin, we will create a raster stack (also created in the previous
-tutorials so you may be able to skip this first step!).
+episodes. To begin, we will create a raster stack (also created in the previous
+episodes so you may be able to skip this first step!).
 
 ```{r load-libraries-data }
 
@@ -92,7 +76,7 @@ NDVI_HARV_stack <- NDVI_HARV_stack/10000
 ```
 
 ## Calculate Average NDVI
-Our goal in this tutorial, is to create a `data.frame` that contains a single,
+Our goal in this episode, is to create a `data.frame` that contains a single,
 mean NDVI value for each raster in our time series. This value represents the
 mean NDVI value for this area on a given day.
 
@@ -204,7 +188,7 @@ Currently, the values in the Julian day column are stored as a `character` class
 Storing this data as a date object is better - for plotting, data subsetting and
 working with our data. Let's convert.
 
-For more information on date-time classes, see the NEON Data Skills tutorial
+For more information on date-time classes, see the NEON Data Skills episode
 [Convert Date & Time Data from Character Class to Date-Time Class (POSIX) in R]({{ site.baseurl }}/R/time-series-convert-date-time-class-POSIX/).
 
 To convert a Julian Day number to a date class, we need to set the **origin**
@@ -310,7 +294,7 @@ plot our data.
 
 We will use the `ggplot()` function within the `ggplot2` package for this plot.
 If you are unfamiliar with `ggplot()` or would like to learn more about plotting
-in `ggplot()` see the tutorial on
+in `ggplot()` see the episode on
 [Plotting Time Series with ggplot in R]({{ site.baseurl }}/R/time-series-plot-ggplot/).
 
 ```{r ggplot-data }
@@ -398,7 +382,7 @@ outlier values that should be removed from the data?
 Let's look at the RGB images from Harvard Forest.
 
 
-NOTE: the code below uses loops which we will not teach in this tutorial.
+NOTE: the code below uses loops which we will not teach in this episode.
 However the code demonstrates one way to plot multiple RGB rasters in a grid.
 
 ```{r view-all-rgb-Harv }
@@ -461,7 +445,7 @@ Let's remove them.
 First, we will identify the good data points - that should be retained. One way
 to do this is by identifying a threhold value. All values below that threshold
 will be removed from our analysis. We will use 0.1 as an example for this
-tutorials. We can then use the subset function to remove outlier datapoints
+episodes. We can then use the subset function to remove outlier datapoints
 (below our identified threshold).
 
 > ## Data Tip

--- a/_episodes_rmd/14-extract-ndvi-from-rasters-in-r.Rmd
+++ b/_episodes_rmd/14-extract-ndvi-from-rasters-in-r.Rmd
@@ -26,7 +26,7 @@ library(ggplot2)
 library(dplyr)
 ```
 
-> ## Things You’ll Need To Complete This episode
+> ## Things You’ll Need To Complete This Episode
 > **R Skill Level:** Intermediate - you've got the basics of `R` down.
 >
 > ### Install software

--- a/_episodes_rmd/14-extract-ndvi-from-rasters-in-r.Rmd
+++ b/_episodes_rmd/14-extract-ndvi-from-rasters-in-r.Rmd
@@ -35,6 +35,25 @@ source("../setup.R")
 knitr_fig_path("14-")
 ```
 
+> ## Things You’ll Need To Complete This episode
+> **R Skill Level:** Intermediate - you've got the basics of `R` down.
+>
+> ### Install software
+> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
+>
+> ### Download Data
+>
+> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
+> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
+>
+> ### Setup RStudio Project
+>
+> Make sure you have setup a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
+>
+> If you don't have a RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
+>
+{: .prereq}
+
 In this tutorial, we will extract NDVI values from a raster time series dataset
 in `R` and plot them using `ggplot`.
 

--- a/index.md
+++ b/index.md
@@ -13,9 +13,11 @@ maintainers:
 - Juan Fung
 ---
 
+**Lesson Authors:** Leah A. Wasser, Megan A. Jones, Zack Brym, Kristina Riemer, Jason Williams, Jeff Hollister,  Mike Smorul, Joseph Stachelek
+
 **Lesson Maintainers:** {{ page.maintainers | join: ', ' }}
 
-The tutorials in this series cover how to open, work with and plot vector and raster-format spatial data in R. Additional topics include working with spatial metadata (extent and coordinate reference systems), reprojecting spatial data, and working with raster time series data.
+The episodes in this lesson cover how to open, work with and plot vector and raster-format spatial data in R. Additional topics include working with spatial metadata (extent and coordinate reference systems), reprojecting spatial data, and working with raster time series data.
 
 > ## Prerequisites
 >

--- a/index.md
+++ b/index.md
@@ -20,6 +20,30 @@ maintainers:
 The episodes in this lesson cover how to open, work with and plot vector and raster-format spatial data in R. Additional topics include working with spatial metadata (extent and coordinate reference systems), reprojecting spatial data, and working with raster time series data.
 
 > ## Prerequisites
+> Data Carpentry’s teaching is hands-on, so participants are encouraged to use 
+> their own computers to ensure the proper setup of tools for an efficient 
+> workflow. To most effectively use these materials, please make sure to download 
+> the data and install everything before working through this lesson. 
+> 
+> ### R Skill Level
+> This lesson assumes you have some knowledge of `R`. If you've never used `R` before, or need
+> a refresher, start with our [Introduction to R for Geospatial Data](http://www.datacarpentry.org/r-intro-geospatial/) lesson.
 >
-> Data Carpentry’s teaching is hands-on, so participants are encouraged to use their own computers to ensure the proper setup of tools for an efficient workflow. These lessons assume no prior knowledge of the skills or tools, but working through this lesson requires working copies of the software described below. To most effectively use these materials, please make sure to download the data and install everything before working through this lesson. Installation instructions can be found on the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
+> ### Geospatial Skill Level
+> This lesson assumes you have some knowledge of geospatial data types and common file formats. If you
+> have never worked with geospatial data before, or need a refresher, start with our [Geospatial Project Organization and Management](http://www.datacarpentry.org/organization-geospatial/) lesson.
+>
+> ### Install Software
+> For installation instructions, see the [workshop homepage](http://www.datacarpentry.org/geospatial-workshop/setup/).
+>
+> ### Download Data
+>
+> * [airborne remote sensing data](https://ndownloader.figshare.com/files/3701578)
+> * [site layout shapefiles](https://ndownloader.figshare.com/files/3708751)
+>
+> ### Setup RStudio Project
+>
+> Make sure you have set up a RStudio project for this lesson, as described in the <a href="{{ site.baseurl }}/setup/" target="_blank">setup instructions</a>.
+>
+> If you don't have an RStudio project, you will need to manually set the working directory with `setwd([your-directory-name])` so R can find the data files to load.
 {: .prereq}


### PR DESCRIPTION
This PR does a lot of things!

A) Structural: 
- Deletes header objects that are not used in the current template. 
- Moves information on authors to the index.md file so it will show up in the lesson homepage along with information about Maintainers. 
- Make libraries load silently where workshop learners will already have them loaded. 
- Moves pre-reqs to the lesson homepage and adds a pointer from the top of each episode to the lesson homepage. 
- Adds links to the introduction to R lesson and the Geospatial project organization lesson to the prereqs on the lesson homepage. 
- Adds time estimates for each episode. These were set at 10 minutes teaching, 0 minutes exercises for each episode. I increased this to 20 minutes teaching, 10 minutes exercises for each episode. This won't be accurate, but it will be a lot closer than current estimates (which are inherited from the lesson template), and can be updated as the lessons are taught by multiple people. This estimate adds up to 7 hours total (including exercises) which is one full day of teaching (excluding lunch).
- Fixes (some) links. 
- Simplifies data loading where possible (e.g. if learners already have data loaded from previous episode).

B) Content: 
- Moves the introduction on vector data from episode 6 to the organization lesson (see https://github.com/datacarpentry/organization-geospatial/pull/31/commits/7efe3b08c936b79897b64a5be166d168bffdbada)
