### PR TITLE
Rename chunk

### DIFF
--- a/_episodes_rmd/05-raster-multi-band-in-r.Rmd
+++ b/_episodes_rmd/05-raster-multi-band-in-r.Rmd
@@ -39,7 +39,7 @@ function in `R`.
 
 ## Getting Started with Multi-Band Data in R
 
-```{r load-libraries, echo = FALSE}
+```{r load-libraries-2, echo = FALSE}
 library(raster)
 library(rgdal)
 ```


### PR DESCRIPTION
Two chunks had the same name. This should fix that and enable the lesson to be rendered.
