### PR TITLE
Cleanup to episode 9

### DIFF
--- a/_episodes_rmd/01-raster-structure.Rmd
+++ b/_episodes_rmd/01-raster-structure.Rmd
@@ -121,22 +121,29 @@ The `CRS` of our `DSM_HARV` object tells us that our data are in the universal t
 		</figcaption>
 </figure>
 
-The CRS in this case is in a `PROJ 4` format. This means that the projection
-information is strung together as a series of text elements, each of which
-begins with a `+` sign.
+## Understanding CRS in Proj4 Format
+The CRS for our data are given to us by `R` in `proj4` format. Let's break
+down the pieces of `proj4` string. The string contains all of the individual
+CRS elements that `R` or another GIS might need. Each element is specified
+with a `+` sign, similar to how a `.csv` file is delimited or broken up by
+a `,`. After each `+` we see the CRS element being defined. For example
+projection (`proj=`) and datum (`datum=`).
 
- `+proj=utm +zone=18 +datum=WGS84 +units=m +no_defs +ellps=WGS84 +towgs84=0,0,0`
+### UTM Proj4 String
+Our project string for `DSM_HARV` specifies the UTM projection as follows:
 
-We'll focus on the first few components of the CRS in this episode.
+`+proj=utm +zone=18 +datum=WGS84 +units=m +no_defs +ellps=WGS84 +towgs84=0,0,0`
 
-* `+proj=utm` The projection of the dataset. Our data are in Universal
-Transverse Mercator (UTM).
-* `+zone=18` The UTM projection divides up the world into zones, this element
-tells you which zone the data is in. Harvard Forest is in Zone 18.
-* `+datum=WGS84` The datum was used to define the center point of the
-projection. Our raster uses the `WGS84` datum.
-* `+units=m` This is the horizontal units that the data are in. Our units
-are meters.
+* **proj=utm:** the projection is UTM, UTM has several zones.
+* **zone=18:** the zone is 18
+* **datum=WGS84:** the datum WGS84 (the datum refers to the  0,0 reference for
+the coordinate system used in the projection)
+* **units=m:** the units for the coordinates are in METERS.
+* **ellps=WGS84:** the ellipsoid (how the earth's  roundness is calculated) for
+the data is WGS84
+
+Note that the `zone` is unique to the UTM projection. Not all CRS will have a
+zone.
 
 ## Calculate Raster Min and Max Values
 

--- a/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
+++ b/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
@@ -120,7 +120,7 @@ Next, let's plot the U.S. states data.
 ```{r find-coordinates }
 ggplot() +
     geom_sf(data=state_boundary_US) +
-    ggtitle("Map of Continental US State Boundaries\n US Census Bureau Data")
+    ggtitle("Map of Contiguous US State Boundaries\n US Census Bureau Data")
 ```
 
 ## U.S. Boundary Layer
@@ -139,7 +139,7 @@ country_boundary_US <- st_read("data/NEON-DS-Site-Layout-Files/US-Boundary-Layer
 ggplot() + 
     geom_sf(data=country_boundary_US, color="gray18", size=2) +
     geom_sf(data=state_boundary_US, color="gray40") +
-    ggtitle("Map of Continental US State Boundaries\n US Census Bureau Data")
+    ggtitle("Map of Contiguous US State Boundaries\n US Census Bureau Data")
 
 ```
 
@@ -165,7 +165,7 @@ ggplot() +
     geom_sf(data=state_boundary_US, color="gray40") +
     # add point tower location
     geom_sf(data=point_HARV, shape=19, color="purple") +
-    ggtitle("Map of Continental US State Boundaries\n with Tower Location")
+    ggtitle("Map of Contiguous US State Boundaries\n with Tower Location")
 ```
 
 What do you notice about the resultant plot? Do you see the tower location in
@@ -312,7 +312,7 @@ ggplot() +
     geom_sf(data=state_boundary_US, color="gray40") +
     # add point tower location
     geom_sf(data=point_HARV_WGS84, shape=19, color="purple") +
-    ggtitle("Map of Continental US State Boundaries\n with Tower Location")
+    ggtitle("Map of Contiguous US State Boundaries\n with Tower Location")
 ```
 
 Reprojecting our data ensured that things line up on our map! It will also

--- a/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
+++ b/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
@@ -60,9 +60,9 @@ raster("data/NEON-DS-Airborne-Remote-Sensing/HARV/CHM/HARV_chmCrop.tif")
 
 To support a project, we often need to gather spatial datasets from
 different sources and/or data that cover different spatial `extents`. These data are often in
-different Coordinate Reference Systems (CRS).
+different Coordinate Reference Systems (CRSs).
 
-Some reasons for data being in different CRS include:
+Some reasons for data being in different CRSs include:
 
 1. The data are stored in a particular CRS convention used by the data
 provider (for example, a government agency).
@@ -188,7 +188,7 @@ st_crs(state_boundary_US)
 st_crs(country_boundary_US)
 ```
 
-It looks like our data are in different CRS. We can tell this by looking at
+It looks like our data are in different CRSs. We can tell this by looking at
 the CRS strings in `proj4` format. We discussed the `proj4` format
 in [an earlier episode]({{site.baseurl}}/01-raster-structure/).
 
@@ -205,7 +205,7 @@ the coordinate system used in the projection)
 * **ellps=WGS84:** the ellipsoid (how the earth's  roundness is calculated) for
 the data is WGS84
 
-Note that the `zone` is unique to the UTM projection. Not all CRS will have a
+Note that the `zone` is unique to the UTM projection. Not all CRSs will have a
 zone.
 
 ### Geographic (lat / long) Proj4 String
@@ -256,7 +256,7 @@ represented in meters.
 
 > ## Proj4 & CRS Resources
 > * <a href="http://proj.maptools.org/faq.html" target="_blank">More information on the proj4 format.</a>
-> * <a href="http://spatialreference.org" target="_blank">A fairly comprehensive list of CRS by format.</a>
+> * <a href="http://spatialreference.org" target="_blank">A fairly comprehensive list of CRSs by format.</a>
 > * To view a list of datum conversion factors type: `projInfo(type = "datum")`
 into the `R` console.
 {: .callout}

--- a/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
+++ b/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
@@ -30,26 +30,43 @@ library(dplyr)
 > data, and other prerequisites you will need to work through the examples in this episode.
 {: .prereq}
 
-In this episode, we will create a base map of our study site using a United States
-state and country boundary accessed from the
+In [an earlier episode]({{ site.baseurl }}/03-raster-reproject-in-r/)
+we learned how to handle a situation where you have two different
+files with raster data in different projections.
+
+Now we will apply those same principles to working with vector data.
+We will create a base map of our study site using United States
+state and country boundary information accessed from the
 <a href="https://www.census.gov/geo/maps-data/data/cbf/cbf_state.html" target="_blank"> United States Census Bureau</a>.
-We will learn how to map vector data that are in different `CRS` and thus
+We will learn how to map vector data that are in different `CRS`s and thus
 don't line up on a map.
 
+We will continue to work with the three shapefiles that we loaded in the
+[Open and Plot Shapefiles in R]({{site.baseurl}}/06-vector-open-shapefile-in-r/) episode.
+
+```{r load-data, echo = FALSE, results='hide', warning=FALSE}
+aoi_boundary_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HarClip_UTMZ18.shp")
+
+lines_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HARV_roads.shp")
+
+point_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HARVtower_UTM18N.shp")
+
+chm_HARV <-
+raster("data/NEON-DS-Airborne-Remote-Sensing/HARV/CHM/HARV_chmCrop.tif")
+```
 
 ## Working With Spatial Data From Different Sources
 
-To support a project, we often need to gather spatial datasets for from
-different sources and/or data that cover different spatial `extents`. Spatial
-data from different sources and that cover different extents are often in
+To support a project, we often need to gather spatial datasets from
+different sources and/or data that cover different spatial `extents`. These data are often in
 different Coordinate Reference Systems (CRS).
 
 Some reasons for data being in different CRS include:
 
 1. The data are stored in a particular CRS convention used by the data
-provider which might be a federal agency, or a state planning office.
+provider which (for example, a government agency).
 2. The data are stored in a particular CRS that is customized to a region.
-For instance, many states prefer to use a **State Plane** projection customized
+For instance, many states in the US prefer to use a State Plane projection customized
 for that state.
 
 <figure>
@@ -72,7 +89,7 @@ are in the same projection to support plotting / mapping. Note that these skills
 are also required for any geoprocessing / spatial analysis. Data need to be in
 the same CRS to ensure accurate results.
 
-We will use the `sf` and `raster` packages in this episode.
+We will continue to use the `sf` and `raster` packages in this episode.
 
 ## Import US Boundaries - Census Data
 
@@ -89,13 +106,11 @@ attributes to them if need be - for project specific mapping.
 
 We will use the `st_read()` function to import the
 `/US-Boundary-Layers/US-State-Boundaries-Census-2014` layer into `R`. This layer
-contains the boundaries of all continental states in the U.S. Please note that
+contains the boundaries of all contiguous states in the U.S. Please note that
 these data have been modified and reprojected from the original data downloaded
 from the Census website to support the learning goals of this episode.
 
-```{r read-csv }
-
-# Read the .csv file
+```{r read-shp }
 state_boundary_US <- st_read("data/NEON-DS-Site-Layout-Files/US-Boundary-Layers/US-State-Boundaries-Census-2014.shp")
 ```
 
@@ -103,26 +118,23 @@ Next, let's plot the U.S. states data.
 
 ```{r find-coordinates }
 
-# view column names
 plot(state_boundary_US$geometry,
-     main = "Map of Continental US State Boundaries\n US Census Bureau Data")
+     main = "Map of contiguous US State Boundaries\n US Census Bureau Data")
 
 ```
 
 ## U.S. Boundary Layer
 
-We can add a boundary layer of the United States to our map - to make it look
-nicer. We will import
+We can add a boundary layer (around the whole map) of the United States to our map. We will import
 `NEON-DS-Site-Layout-Files/US-Boundary-Layers/US-Boundary-Dissolved-States`.
 If we specify a thicker line width using `lwd = 4` for the border layer, it will
-make our map pop!
+make our map look nice!
 
 ```{r check-out-coordinates }
-# Read the .csv file
 country_boundary_US <- st_read("data/NEON-DS-Site-Layout-Files/US-Boundary-Layers/US-Boundary-Dissolved-States.shp")
 
 plot(state_boundary_US$geometry,
-     main = "Map of Continental US State Boundaries\n US Census Bureau Data",
+     main = "Map of contiguous US State Boundaries\n US Census Bureau Data",
      border = "gray40")
 
 plot(country_boundary_US$geometry,
@@ -136,8 +148,6 @@ Next, let's add the location of a flux tower where our study area is.
 As we are adding these layers, take note of the class of each object.
 
 ```{r explore-units}
-# Import a point shapefile
-point_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HARVtower_UTM18N.shp")
 
 # plot point - looks ok?
 plot(point_HARV$geometry,
@@ -151,18 +161,18 @@ will plot! Let's next add it as a layer on top of the U.S. states and boundary
 layers in our basemap plot.
 
 ``` {r layer-point-on-states }
-# plot state boundaries
+
 plot(state_boundary_US$geometry,
-     main = "Map of Continental US State Boundaries \n with Tower Location",
+     main = "Map of contiguous US State Boundaries \n with Tower Location",
      border = "gray40")
 
-# add US border outline
+
 plot(country_boundary_US$geometry,
      lwd = 4,
      border = "gray18",
      add = TRUE)
 
-# add point tower location
+
 plot(point_HARV$geometry,
      pch = 19,
      col = "purple",
@@ -177,29 +187,25 @@ Let's check out the CRS (`st_crs()`) of both datasets to see if we can identify 
 issues that might cause the point location to not plot properly on top of our
 U.S. boundary layers.
 
-```{r crs-sleuthing}
+First we'll look at the CRS of our study site.
 
-# view CRS of our site data
+```{r crs-sleuthing-1}
 st_crs(point_HARV)
+```
 
-# view crs of census data
+Then we'll look at the CRS of the US map data.
+
+```{r crs-sleuthing-2}
 st_crs(state_boundary_US)
 st_crs(country_boundary_US)
 ```
 
 It looks like our data are in different CRS. We can tell this by looking at
-the CRS strings in `proj4` format.
-
-## Understanding CRS in Proj4 Format
-The CRS for our data are given to us by `R` in `proj4` format. Let's break
-down the pieces of `proj4` string. The string contains all of the individual
-CRS elements that `R` or another GIS might need. Each element is specified
-with a `+` sign, similar to how a `.csv` file is delimited or broken up by
-a `,`. After each `+` we see the CRS element being defined. For example
-projection (`proj=`) and datum (`datum=`).
+the CRS strings in `proj4` format. We discussed the `proj4` format
+in [an earlier episode]({{site.baseurl}}/01-raster-structure/).
 
 ### UTM Proj4 String
-Our project string for `point_HARV` specifies the UTM projection as follows:
+Our project string for `DSM_HARV` specifies the UTM projection as follows:
 
 `+proj=utm +zone=18 +datum=WGS84 +units=m +no_defs +ellps=WGS84 +towgs84=0,0,0`
 
@@ -230,7 +236,7 @@ is WGS84
 
 Note that there are no specified units above. This is because this geographic
 coordinate reference system is in latitude and longitude which is most
-often recorded in *Decimal Degrees*.
+often recorded in decimal degrees.
 
 > ## Data Tip
 > the last portion of each `proj4` string
@@ -243,14 +249,16 @@ often recorded in *Decimal Degrees*.
 Next, let's view the extent or spatial coverage for the `point_HARV` spatial
 object compared to the `state_boundary_US` object.
 
-```{r view-extent }
+First we'll look at the extent for our study site:
 
-# extent for HARV in UTM
+```{r view-extent-1}
 st_bbox(point_HARV)
+```
 
-# extent for object in geographic
+And then the extent for the state boundary data.
+
+```{r view-extent-2}
 st_bbox(state_boundary_US)
-
 ```
 
 Note the difference in the units for each object. The extent for
@@ -258,24 +266,20 @@ Note the difference in the units for each object. The extent for
 representing decimal degree units. Our tower location point is in UTM, is
 represented in meters.
 
-***
-
-## Proj4 & CRS Resources
-
-* <a href="http://proj.maptools.org/faq.html" target="_blank">More information on the proj4 format.</a>
-* <a href="http://spatialreference.org" target="_blank">A fairly comprehensive list of CRS by format.</a>
-* To view a list of datum conversion factors type: `projInfo(type = "datum")`
+> ## Proj4 & CRS Resources
+> * <a href="http://proj.maptools.org/faq.html" target="_blank">More information on the proj4 format.</a>
+> * <a href="http://spatialreference.org" target="_blank">A fairly comprehensive list of CRS by format.</a>
+> * To view a list of datum conversion factors type: `projInfo(type = "datum")`
 into the `R` console.
-
-***
+{: .callout}
 
 ## Reproject Vector Data
 
-Now we know our data are in different CRS. To address this, we have to modify
-or **reproject** the data so they are all in the **same** CRS. We can use
+Now we know our data are in different CRSs. To address this, we have to modify
+or reproject the data so they are all in the same CRS. We can use
 `st_transform()` function to reproject our data. When we reproject the data, we
 specify the CRS that we wish to transform our data to. This CRS contains
-the datum, units and other information that `R` needs to **reproject** our data.
+the datum, units and other information that `R` needs to reproject our data.
 
 The `st_transform()` function requires two inputs:
 
@@ -293,15 +297,20 @@ use the `st_crs()` of the `state_boundary_US` object as follows:
 Next, let's reproject our point layer into the geographic - latitude and
 longitude `WGS84` coordinate reference system (CRS).
 
+First we will reproject the data and check the CRS of the new object.
+
 ```{r crs-st_tranform }
 
-# reproject data
 point_HARV_WGS84 <- st_transform(point_HARV,
                                 st_crs(state_boundary_US))
 
-# what is the CRS of the new object
 st_crs(point_HARV_WGS84)
-# does the extent look like decimal degrees?
+```
+
+We can also double check the extent of the new object to make sure
+it looks like decimal degrees.
+
+```{r}
 st_bbox(point_HARV_WGS84)
 ```
 
@@ -309,18 +318,15 @@ Once our data are reprojected, we can try to plot again.
 
 ```{r plot-again }
 
-# plot state boundaries
 plot(state_boundary_US$geometry,
-     main = "Map of Continental US State Boundaries\n With Fisher Tower Location",
+     main = "Map of contiguous US State Boundaries\n With Fisher Tower Location",
      border = "gray40")
 
-# add US border outline
 plot(country_boundary_US$geometry,
      lwd = 4,
      border = "gray18",
      add = TRUE)
 
-# add point tower location
 plot(point_HARV_WGS84$geometry,
      pch = 19,
      col = "purple",


### PR DESCRIPTION
Based on comments in https://github.com/datacarpentry/r-raster-vector-geospatial/issues/165. 

This PR does the following:
[Episode 9](https://datacarpentry.org/r-raster-vector-geospatial/09-vector-when-data-dont-line-up-crs/index.html)
- [ ] Remove comments and move that information to the narrative text to fit the rest of DC lessons.
- [x] Replace "continental" with "contiguous" - "continental" includes Alaska, which is not shown here.
- [x] Move additional resources to a callout box. 
- [x] Add reference back to first episode when talking about proj4 format.


