### PR TITLE
Convert episode 9 plotting to ggplot

### DIFF
--- a/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
+++ b/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
@@ -21,6 +21,7 @@ knitr_fig_path("09-")
 ```{r load-libraries, echo = FALSE, results='hide'}
 library(raster)
 library(rgdal)
+library(sf)
 library(ggplot2)
 library(dplyr)
 ```
@@ -103,32 +104,17 @@ Next, let's plot the U.S. states data.
 
 ```{r find-coordinates }
 
-# view column names
-plot(state_boundary_US$geometry,
-     main = "Map of Continental US State Boundaries\n US Census Bureau Data")
+# plot state boundaries
+ggplot() +
+    geom_sf(data=state_boundary_US) +
+    ggtitle("Map of Continental US State Boundaries\n US Census Bureau Data")
 
 ```
 
 ## U.S. Boundary Layer
 
-We can add a boundary layer of the United States to our map - to make it look
-nicer. We will import
-`NEON-DS-Site-Layout-Files/US-Boundary-Layers/US-Boundary-Dissolved-States`.
-If we specify a thicker line width using `lwd = 4` for the border layer, it will
-make our map pop!
-
-```{r check-out-coordinates }
-# Read the .csv file
-country_boundary_US <- st_read("data/NEON-DS-Site-Layout-Files/US-Boundary-Layers/US-Boundary-Dissolved-States.shp")
-
-plot(state_boundary_US$geometry,
-     main = "Map of Continental US State Boundaries\n US Census Bureau Data",
-     border = "gray40")
-
-plot(country_boundary_US$geometry,
-     lwd = 4,
-     border = "gray18",
-     add = TRUE)
+    geom_sf(data=state_boundary_US, color="gray40") +
+     ggtitle("Map of Continental US State Boundaries\n US Census Bureau Data")
 
 ```
 
@@ -140,10 +126,9 @@ As we are adding these layers, take note of the class of each object.
 point_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HARVtower_UTM18N.shp")
 
 # plot point - looks ok?
-plot(point_HARV$geometry,
-     pch = 19,
-     col = "purple",
-     main = "Harvard Fisher Tower Location")
+ggplot() +
+    geom_sf(data=point_HARV, shape=19, color="purple") +
+    ggtitle("Harvard Fisher Tower Location")
 ```
 
 The plot above demonstrates that the tower point location data is readable and
@@ -151,22 +136,14 @@ will plot! Let's next add it as a layer on top of the U.S. states and boundary
 layers in our basemap plot.
 
 ``` {r layer-point-on-states }
-# plot state boundaries
-plot(state_boundary_US$geometry,
-     main = "Map of Continental US State Boundaries \n with Tower Location",
-     border = "gray40")
-
-# add US border outline
-plot(country_boundary_US$geometry,
-     lwd = 4,
-     border = "gray18",
-     add = TRUE)
-
-# add point tower location
-plot(point_HARV$geometry,
-     pch = 19,
-     col = "purple",
-     add = TRUE)
+ggplot() +
+    # plot state boundaries
+    geom_sf(data=country_boundary_US, size=2, color="gray18") +
+    # add US border outline
+    geom_sf(data=state_boundary_US, color="gray40") +
+    # add point tower location
+    geom_sf(data=point_HARV, shape=19, color="purple") +
+    ggtitle("Map of Continental US State Boundaries\n with Tower Location")
 
 ```
 
@@ -309,22 +286,14 @@ Once our data are reprojected, we can try to plot again.
 
 ```{r plot-again }
 
-# plot state boundaries
-plot(state_boundary_US$geometry,
-     main = "Map of Continental US State Boundaries\n With Fisher Tower Location",
-     border = "gray40")
-
-# add US border outline
-plot(country_boundary_US$geometry,
-     lwd = 4,
-     border = "gray18",
-     add = TRUE)
-
-# add point tower location
-plot(point_HARV_WGS84$geometry,
-     pch = 19,
-     col = "purple",
-     add = TRUE)
+ggplot() +
+    # plot state boundaries
+    geom_sf(data=country_boundary_US, size=2, color="gray18") +
+    # add US border outline
+    geom_sf(data=state_boundary_US, color="gray40") +
+    # add point tower location
+    geom_sf(data=point_HARV_WGS84, shape=19, color="purple") +
+    ggtitle("Map of Continental US State Boundaries\n with Tower Location")
 
 ```
 
@@ -361,26 +330,23 @@ transformations) on our data.
 > >                                 UTM_CRS)
 > > NE.States.Boundary.US.UTM
 > > 
-> > # plot state boundaries
-> > plot(NE.States.Boundary.US.UTM$geometry,
-> >      main = "Map of Northeastern US\n With Fisher Tower Location - UTM Zone 18N",
-> >      border="gray18",
-> >      lwd = 2)
-> > 
-> > # add point tower location
-> > plot(point_HARV$geometry,
-> >      pch = 19,
-> >      col = "purple",
-> >      add = TRUE)
-> > 
-> > # add legend
 > > # to create a custom legend, we need to fake it
-> > legend("bottomright",
-> >        legend = c("State Boundary", "Fisher Tower"),
-> >        lty = c(1, NA),
-> >        pch = c(NA, 19),
-> >        col = c("gray18", "purple"),
-> >        bty = "n")
+> > ggplot() +
+> >     # plot state boundaries
+> >     # note the use of an aesthetic, `aes`, which will allow you to customize your legend
+> >     geom_sf(data=NE.States.Boundary.US.UTM, size=1, aes(color="color"), show.legend="line") +
+> >     # `scale_xx_manual` allows you to customize your legend
+> >     # note how the values correspond to the aesthetic
+> >     scale_color_manual(name="", labels="State Boundary", values=c("color"="gray18")) +
+> >     # add point tower location, and customize legend as before
+> >     geom_sf(data=point_HARV, aes(shape="shape"), color="purple") +
+> >     scale_shape_manual(name="", labels="Fisher Tower", values=c("shape"=19)) +
+> >     ggtitle("Map of Northeastern US\n With Fisher Tower Location - UTM Zone 18N") +
+> >     # you can customize the legend's appearance with `theme`
+> >     theme(legend.position="bottom",
+> >           legend.background = element_rect(color = NA)) 
+> > 
+> > 
 > > 
 > > ```
 > {: .solution}


### PR DESCRIPTION
Per #133: This is a straight conversion of episode 9 plots to use `ggplot`. Also, following earlier conventions, explicitly calling `library(sf)` in the second code chunk.

An important remark for follow-up:

- `geom_sf` automatically transforms the CRS of additional layers (see second example in documentation [here](https://ggplot2.tidyverse.org/reference/ggsf.html)). Thus, the fourth plot shows the tower point in the correct location (it shouldn't appear on the map since each layer has a different CRS).

I will open an issue corresponding to this part of the episode.