### PR TITLE
add sudo: required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ after_script: R -q -e 'tic::after_script()'
 
 # Header
 language: r
-sudo: false
+sudo: required
 dist: trusty
 cache: packages
 latex: false


### PR DESCRIPTION
Travis CI builds are failing and giving the error message below:

> This job is running on container-based infrastructure, which does not allow use of 'sudo', setuid, and setguid executables. If you require sudo, add 'sudo: required' to your .travis.yml.
