### PR TITLE
Cleanup to episode 11

### DIFF
--- a/_episodes_rmd/11-vector-raster-integration.Rmd
+++ b/_episodes_rmd/11-vector-raster-integration.Rmd
@@ -26,7 +26,7 @@ library(dplyr)
 ```
 
 
-```{r load-data, echo = FALSE}
+```{r load-data, echo = FALSE, results='hide'}
 # Learners will have this data loaded from earlier episodes
 # shapefiles
 point_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HARVtower_UTM18N.shp")
@@ -52,7 +52,7 @@ CHM_HARV_df <- CHM_HARV  %>%
 # plot locations
 plot_locations_HARV <-
   read.csv("data/NEON-DS-Site-Layout-Files/HARV/HARV_PlotLocations.csv")
-utm18nCRS <- st_crs(lines_HARV)
+utm18nCRS <- st_crs(point_HARV)
 plot_locations_sp_HARV <- st_as_sf(plot_locations_HARV, coords = c("easting", "northing"), crs = utm18nCRS)
 ```
 
@@ -88,15 +88,19 @@ we have worked with in this workshop:
 * A canopy height model (CHM) in GeoTIFF format -- green
 
 ```{r view-extents, echo=FALSE}
+# create CHM as a shapefile
 CHM_HARV_sp <- st_as_sf(CHM_HARV_df, coords = c("x", "y"), crs = utm18nCRS)
 # approximate the boundary box with random sample of raster points
 CHM_rand_sample = sample_n(CHM_HARV_sp, 10000)
+```
 
+```{r, echo = FALSE}
 ggplot() + 
-  geom_sf(data = st_convex_hull(st_union(CHM_rand_sample)), color = "green") +
-  geom_sf(data = st_convex_hull(st_union(lines_HARV)), color = "purple") +
-  geom_sf(data = aoi_boundary_HARV$geometry, color = "blue") +
-  geom_sf(data = st_convex_hull(st_union(plot_locations_sp_HARV)), color = "black")
+  geom_sf(data = st_convex_hull(st_union(CHM_rand_sample)), fill = "green") +
+  geom_sf(data = st_convex_hull(st_union(lines_HARV)), fill = "purple", aes(alpha = 0.1)) +
+  geom_sf(data = aoi_boundary_HARV, fill = "blue") +
+  geom_sf(data = st_convex_hull(st_union(plot_locations_sp_HARV)), fill = "black") + 
+  theme(legend.position = "none")
 ```
 
 ```{r reset-par, results="hide", echo=FALSE }
@@ -151,7 +155,7 @@ same extent as the `aoi_boundary_HARV` object that was used as a crop extent
 
 ```{r view-crop-extent, echo=FALSE}
 ggplot() + 
-    geom_sf(data = aoi_boundary_HARV$geometry, color = "blue") + 
+    geom_sf(data = aoi_boundary_HARV, color = "blue") + 
   geom_raster(data = CHM_HARV_Crop_df, aes(x = x, y = y, fill = layer)) + 
      scale_fill_gradientn(name = "Canopy Height", colors = terrain.colors(10)) + 
   ggtitle("LiDAR CHM - Cropped\nNEON Harvard Forest Field Site")
@@ -185,93 +189,83 @@ vegetation plot locations plotted on top of the Canopy Height Model information.
 > > ggplot() + 
 > >   geom_raster(data = CHM_plots_HARVcrop_df, aes(x = x, y = y, fill = layer)) + 
 > >   scale_fill_gradientn(name = "Canopy Height", colors = terrain.colors(10)) + 
-> >   geom_sf(data = plot_locations_sp_HARV$geometry) + 
+> >   geom_sf(data = plot_locations_sp_HARV) + 
 > >   ggtitle("Study Plot Locations\n NEON Harvard Forest")
 > > ```
 > {: .solution}
 {: .challenge}
 
 In the plot above, created in the challenge, all the vegetation plot locations
-(blue) appear on the Canopy Height Model raster layer except for one. One is
+(black dots) appear on the Canopy Height Model raster layer except for one. One is
 situated on the blank space to the left of the map. Why?
 
 A modification of the first figure in this episode is below, showing the
 relative extents of all the spatial objects. Notice that the extent for our
 vegetation plot layer (black) extends further west than the extent of our CHM
-raster (bright green). The crop function will make a raster extent smaller, it
-will not expand the extent in areas where there are no data. Thus, extent of our
+raster (bright green). The `crop()` function will make a raster extent smaller, it
+will not expand the extent in areas where there are no data. Thus, the extent of our
 vegetation plot layer will still extend further west than the extent of our
 (cropped) raster data (dark green).
 
-``` {r raster-extents-cropped, echo=FALSE}
-plot(st_convex_hull(st_union(lines_HARV)),
-     col = "purple", lwd = "3",
-     xlab = "Easting", ylab = "Northing",
-    main = "Extent Boundary of Several Spatial Files")
+```{r, echo = FALSE}
+# create CHM_plots_HARVcrop as a shape file
+CHM_plots_HARVcrop_sp <- st_as_sf(CHM_plots_HARVcrop_df, coords = c("x", "y"), crs = utm18nCRS)
+# approximate the boundary box with random sample of raster points
+CHM_plots_HARVcrop_sp_rand_sample = sample_n(CHM_plots_HARVcrop_sp, 10000)
+```
 
-plot(st_convex_hull(st_union(plot_locations_sp_HARV)),
-     col = "black",
-     add = TRUE)
-
-plot(extent(chm_HARV),
-     add = TRUE,
-     lwd = 5,
-     col = "springgreen")
-
-plot(extent(CHM_plots_HARVcrop),
-     add = TRUE,
-     lwd = 5,
-     col = "darkgreen")
-
-legend("bottomright",
-        legend = c("Roads", "Plot Locations", "CHM", "CHM cropped to Plots"),
-       lwd = 3,
-       col = c("purple", "black", "springgreen", "darkgreen"),
-       bty = "n",
-       cex = .8)
-
+```{r, echo = FALSE}
+ggplot() + 
+  geom_sf(data = st_convex_hull(st_union(CHM_rand_sample)), fill = "green") +
+  geom_sf(data = st_convex_hull(st_union(lines_HARV)), fill = "purple", aes(alpha = 0.1)) +
+  geom_sf(data = st_convex_hull(st_union(CHM_plots_HARVcrop_sp_rand_sample)), fill = "darkgreen") +
+  geom_sf(data = st_convex_hull(st_union(plot_locations_sp_HARV)), fill = "black") + 
+  geom_sf(data = aoi_boundary_HARV, fill = "blue") +
+  theme(legend.position = "none")
 ```
 
 ## Define an Extent
-We can also use an `extent()` method to define an extent to be used as a cropping
-boundary. This creates an object of class `extent`.
+So far, we have used a shapefile to crop the extent of a raster dataset. Alternatively,
+we can also the
+`extent()` function to define an extent to be used as a cropping
+boundary. This creates a new object of class `Extent`. Here we will 
+provide the `extent()`
+function our xmin, xmax, ymin, and ymax (in that order). 
 
 ```{r hidden-extent-chunk}
-# extent format (xmin, xmax, ymin, ymax)
 new.extent <- extent(732161.2, 732238.7, 4713249, 4713333)
 class(new.extent)
 ```
 
-Once we have defined the extent, we can use the `crop` function to crop our
-raster.
+> ## Data Tip
+> The `extent()` function can be created from a numeric vector (as shown above),
+> a matrix, or a list. For more details see the `extent()` function help file. 
+> * `??raster::extent`
+> * More on the [extent class in `R`](http://www.inside-r.org/packages/cran/raster/docs/extent).
+{: .callout}
+
+Once we have defined our new extent, we can use the `crop()` function to crop our
+raster to this extent object.
 
 ```{r crop-using-drawn-extent}
-
-# crop raster
-CHM_HARV_manualCrop <- crop(x = chm_HARV, y = new.extent)
-
-# plot extent boundary and newly cropped raster
-plot(aoi_boundary_HARV$geometry,
-     main = "Manually Cropped Raster\n NEON Harvard Forest Field Site")
-plot(new.extent,
-     col = "brown",
-     lwd = 4,
-     add = TRUE)
-plot(CHM_HARV_manualCrop,
-     add = TRUE)
+CHM_HARV_manualCrop <- crop(x = CHM_HARV, y = new.extent)
 ```
 
-Notice that our manual `new.extent` (in red) is smaller than the
-`aoi_boundary_HARV` and that the raster is now the same as the `new.extent`
-object.
+To plot this data using `ggplot()` we need to convert it to a dataframe. 
 
-See the documentation for the `extent()` function for more ways
-to create an `extent` object.
+```{r}
+CHM_HARV_manualCrop_df <- raster::as.data.frame(CHM_HARV_manualCrop, xy = TRUE)
+```
 
-* `??raster::extent`
-* More on the
-<a href="http://www.inside-r.org/packages/cran/raster/docs/extent" target="_blank">
-extent class in `R`</a>.
+Now we can plot this cropped data. We will show the AOI boundary on the same plot for scale.
+
+```{r}
+ggplot() + 
+    geom_sf(data = aoi_boundary_HARV, color = "blue") +
+    geom_raster(data = CHM_HARV_manualCrop_df, aes(x = x, y = y, fill = layer)) + 
+    scale_fill_gradientn(name = "Canopy Height", colors = terrain.colors(10)) + 
+    ggtitle("NEON Harvard Forest\n Manually cropped")
+```
 
 ## Extract Raster Pixels Values Using Vector Polygons
 
@@ -279,8 +273,8 @@ Often we want to extract values from a raster layer for particular locations -
 for example, plot locations that we are sampling on the ground.
 
 <figure>
-    <a href="http://neondataskills.org/images/spatialData/BufferSquare.png">
-    <img src="http://neondataskills.org/images/spatialData/BufferSquare.png"></a>
+    <a href="https://www.neonscience.org/sites/default/files/images/spatialData/BufferSquare.png">
+    <img src="https://www.neonscience.org/sites/default/files/images/spatialData/BufferSquare.png"></a>
     <figcaption> Extract raster information using a polygon boundary. We can
     extract all pixel values within 20m of our x,y point of interest. These can
     then be summarized into some value of interest (e.g. mean, maximum, total).
@@ -295,55 +289,47 @@ requires:
 * The vector layer containing the polygons that we wish to use as a boundary or
 boundaries,
 * we can tell it to store the output values in a `data.frame` using
-`df=TRUE` (optional, default is to NOT return a `data.frame`) .
+`df=TRUE` (This is optional, the default is to return a list, NOT a dataframe.) .
 
 We will begin by extracting all canopy height pixel values located within our
-`aoiBoundary` polygon which surrounds the tower located at the NEON Harvard
+`aoi_boundary_HARV` polygon which surrounds the tower located at the NEON Harvard
 Forest field site.
 
 ```{r extract-from-raster}
 
-# extract tree height for AOI
-# set df=TRUE to return a data.frame rather than a list of values
-tree_height <- extract(x = chm_HARV,
+tree_height <- extract(x = CHM_HARV,
                        y = as(aoi_boundary_HARV, "Spatial"),
                        df = TRUE)
 
-# view the object
-head(tree_height)
-
-nrow(tree_height)
+str(tree_height)
 ```
 
-When we use the extract command, `R` extracts the value for each pixel located
+When we use the `extract()` function, `R` extracts the value for each pixel located
 within the boundary of the polygon being used to perform the extraction - in
-this case the `aoiBoundary` object (1 single polygon). In this case, the
+this case the `aoi_boundary_HARV` object (a single polygon). In this case, the
 function extracted values from 18,450 pixels.
 
-The `extract` function returns a `list` of values as default. You can tell `R`
-to summarize the data in some way or to return the data as a `data.frame`
-(`df=TRUE`).
-
 We can create a histogram of tree height values within the boundary to better
-understand the structure or height distribution of trees. We can also use the
-`summary()` function to view descriptive statistics including min, max and mean
+understand the structure or height distribution of trees at our site. We will
+use the column `layer` from our dataframe as our x values, as this column
+represents the tree heights for each pixel.
+
+```{r view-extract-histogram}
+ggplot() + 
+  geom_histogram(data = tree_height, aes(x = layer)) +
+  ggtitle("Histogram of CHM Height Values (m) \nNEON Harvard Forest Field Site") +
+  xlab("Tree Height") + 
+  ylab("Frequency of Pixels")
+```
+
+ We can also use the
+`summary()` function to view descriptive statistics including min, max, and mean
 height values. These values help us better understand vegetation at our field
 site.
 
-```{r view-extract-histogram}
-# view histogram of tree heights in study area
-hist(tree_height$HARV_chmCrop,
-     main = "Histogram of CHM Height Values (m) \nNEON Harvard Forest Field Site",
-     col = "springgreen",
-     xlab = "Tree Height", ylab = "Frequency of Pixels")
-
-# view summary of values
-summary(tree_height$HARV_chmCrop)
-
+```{r}
+summary(tree_height$layer)
 ```
-
-* Check out the documentation for the `extract()` function for more details
-(`??raster::extract`).
 
 ## Summarize Extracted Raster Values
 

--- a/_episodes_rmd/11-vector-raster-integration.Rmd
+++ b/_episodes_rmd/11-vector-raster-integration.Rmd
@@ -103,10 +103,6 @@ ggplot() +
   theme(legend.position = "none")
 ```
 
-```{r reset-par, results="hide", echo=FALSE }
-dev.off()
-```
-
 Frequent use cases of cropping a raster file include reducing file size and
 creating maps. Sometimes we have a raster file that is much larger than our
 study area or area of interest. It is often more efficient to crop the
@@ -155,7 +151,7 @@ same extent as the `aoi_boundary_HARV` object that was used as a crop extent
 
 ```{r view-crop-extent, echo=FALSE}
 ggplot() +
-    geom_sf(data = aoi_boundary_HAR, color = "blue") + 
+    geom_sf(data = aoi_boundary_HARV, color = "blue") + 
   geom_raster(data = CHM_HARV_Crop_df, aes(x = x, y = y, fill = layer)) + 
      scale_fill_gradientn(name = "Canopy Height", colors = terrain.colors(10)) + 
   ggtitle("LiDAR CHM - Cropped\nNEON Harvard Forest Field Site")
@@ -232,7 +228,7 @@ boundary. This creates a new object of class `Extent`. Here we will
 provide the `extent()`
 function our xmin, xmax, ymin, and ymax (in that order). 
 
-```{r hidden-extent-chunk}
+```{r}
 new.extent <- extent(732161.2, 732238.7, 4713249, 4713333)
 class(new.extent)
 ```
@@ -334,98 +330,81 @@ summary(tree_height$layer)
 ## Summarize Extracted Raster Values
 
 We often want to extract summary values from a raster. We can tell `R` the type
-of summary statistic we are interested in using the `fun=` method. Let's extract
-a mean height value for our AOI.
+of summary statistic we are interested in using the `fun =` argument. Let's extract
+a mean height value for our AOI. Because we are extracting only a single number, we will
+not use the `df = TRUE` argument. 
 
 ```{r summarize-extract }
-# extract the average tree height (calculated using the raster pixels)
-# located within the AOI polygon
-av_tree_height_AOI <- extract(x = chm_HARV,
+mean_tree_height_AOI <- extract(x = CHM_HARV,
                               y = as(aoi_boundary_HARV, "Spatial"),
-                              fun = mean,
-                              df = TRUE)
+                              fun = mean)
 
-# view output
-av_tree_height_AOI
-
+mean_tree_height_AOI
 ```
 
 It appears that the mean height value, extracted from our LiDAR data derived
-canopy height model is 22.43 meters.
+canopy height model is 19.34 meters.
 
-##Extract Data using x,y Locations
+## Extract Data using x,y Locations
 
 We can also extract pixel values from a raster by defining a buffer or area
 surrounding individual point locations using the `extract()` function. To do this
-we define the summary method (`fun=mean`) and the buffer distance (`buffer=20`)
-which represents the radius of a circular region around each point.
-
-The units of the buffer are the same units of the data `CRS`.
+we define the summary argument (`fun = mean`) and the buffer distance (`buffer = 20`)
+which represents the radius of a circular region around each point. By default, the units of the
+buffer are the same units as the data's CRS.
 
 <figure>
-    <a href="http://neondataskills.org/images/spatialData/BufferCircular.png">
-    <img src="http://neondataskills.org/images/spatialData/BufferCircular.png"></a>
+    <a href="https://www.neonscience.org/sites/default/files/images/spatialData/BufferCircular.png">
+    <img src="https://www.neonscience.org/sites/default/files/images/spatialData/BufferCircular.png"></a>
     <figcaption> Extract raster information using a buffer region. All pixels
     that are touched by the buffer region are included in the extract.
     Source: National Ecological Observatory Network (NEON).
     </figcaption>
 </figure>
 
-Let's put this into practice by figuring out the average tree height in the
-20m around the tower location.
+Let's put this into practice by figuring out the mean tree height in the
+20m around the tower location (`point_HARV`). Because we are extracting only a single number, we
+will not use the `df = TRUE` argument. 
 
 ```{r extract-point-to-buffer }
-# what are the units of our buffer
-st_crs(point_HARV)
-
-# extract the average tree height (height is given by the raster pixel value)
-# at the tower location
-# use a buffer of 20 meters and mean function (fun)
-av_tree_height_tower <- extract(x = chm_HARV,
+mean_tree_height_tower <- extract(x = CHM_HARV,
                                 y = as(point_HARV, "Spatial"),
                                 buffer = 20,
-                                fun = mean,
-                                df = TRUE)
+                                fun = mean)
 
-# view data
-head(av_tree_height_tower)
-
-# how many pixels were extracted
-nrow(av_tree_height_tower)
-
+mean_tree_height_tower
 ```
 
 > ## Challenge: Extract Raster Height Values For Plot Locations
 > 
-> Use the plot location points shapefile `HARV/plot_locations_HARV.shp` or spatial
-> object `plot_locations_sp_HARV` to extract an average tree height value for the
-> area within 20m of each vegetation plot location in the study area.
+> 1) Use the plot locations object (`plot_locations_sp_HARV`)
+> to extract an average tree height for the
+> area within 20m of each vegetation plot location in the study area. Because there are 
+> multiple plot locations, there will be multiple averages returned, so the `df = TRUE` 
+> argument should be used.
 > 
-> Create a simple plot showing the mean tree height of each plot using the `plot()`
-> function in base-R.
+> 2) Create a plot showing the mean tree height of each area. 
 > 
 > > ## Answers
 > > 
-> > ```{r challenge-code-extract-plot-tHeight, include=TRUE, results="hide", echo=TRUE}
-> > 
-> > # first import the plot location file.
-> > plot_locations_sp_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/PlotLocations_HARV.shp")
+> > ```{r}
 > > 
 > > # extract data at each plot location
-> > meanTreeHt_plots_HARV <- extract(x = chm_HARV,
+> > meanTreeHt_plots_HARV <- extract(x = CHM_HARV,
 > >                                y = as(plot_locations_sp_HARV, "Spatial"),
 > >                                buffer=20,
-> >                                fun=mean,
-> >                                df=TRUE)
+> >                                fun = mean,
+> >                                df = TRUE)
 > > 
 > > # view data
 > > meanTreeHt_plots_HARV
 > > 
 > > # plot data
-> > plot(meanTreeHt_plots_HARV,
-> >      main = "MeanTree Height at each Plot\nNEON Harvard Forest Field Site",
-> >      xlab = "Plot ID", ylab = "Tree Height (m)",
-> >      pch=16)
+> > ggplot(data = meanTreeHt_plots_HARV, aes(ID, layer)) + 
+> >   geom_col() + 
+> >   ggtitle("Mean Tree Height at each Plot") + 
+> >   xlab("Plot ID") + 
+> >   ylab("Tree Height (m)")
 > > ```
 > {: .solution}
 {: .challenge}

--- a/_episodes_rmd/11-vector-raster-integration.Rmd
+++ b/_episodes_rmd/11-vector-raster-integration.Rmd
@@ -302,7 +302,7 @@ str(tree_height)
 
 When we use the `extract()` function, `R` extracts the value for each pixel located
 within the boundary of the polygon being used to perform the extraction - in
-this case the `aoi_boundary_HARV` object (a single polygon). In this case, the
+this case the `aoi_boundary_HARV` object (a single polygon). Here, the
 function extracted values from 18,450 pixels.
 
 We can create a histogram of tree height values within the boundary to better


### PR DESCRIPTION
This PR continues cleanup to episode 11 as discussed in https://github.com/datacarpentry/r-raster-vector-geospatial/issues/165. 

The following changes are included. 

[Episode 11](https://datacarpentry.org/r-raster-vector-geospatial/11-vector-raster-integration/index.html)

- [x] Needs to be ggplotized. **Discussed in https://github.com/datacarpentry/r-raster-vector-geospatial/issues/133** **Partially addressed in https://github.com/datacarpentry/r-raster-vector-geospatial/pull/217**
- [x] Move comments to narrative for stylistic consistency. 
- [x] Remove line starting "If you completed .csv to Shapefile in R you have these plot"
- [x] Move bullet point extra resources to callout (multiple places)
- [x] Broken image link at start of "Extract Raster Pixels Values Using Vector Polygons"
- [x] Sentence fragment - meant to be a section header? "Extract raster information using a polygon boundary."
- [x] "In this case," used twice in adjoining sentences. 
- [x] `data.frame` and `list` should be plain text. 
- [x] Broken header "##Extract Data using x,y Locations"
- [x] Broken image link in ##Extract Data using x,y Locations section