### PR TITLE
mixed up ( ] in cut.

### DIFF
--- a/_episodes_rmd/02-raster-plot.Rmd
+++ b/_episodes_rmd/02-raster-plot.Rmd
@@ -98,7 +98,7 @@ unique(DSM_HARV_df$fct_elevation_2)
 > ## Data Tips
 > Note that when we assign break values a set of 4 values will result in 3 bins of data.
 >
-> The bin intervals are shown using `(` to mean inclusive and `]` to mean exclusive. For example: `(305, 342]` means "from 305 through 341".
+> The bin intervals are shown using `(` to mean exclusive and `]` to mean inclusive. For example: `(305, 342]` means "from 306 through 342".
 {: .callout}
 
 And now we can plot our bar plot again, using the new groups:


### PR DESCRIPTION
Hello Erin, 
just a small bug fix. In the text ( and ] are mixed up. Here a small example:
```
> library(dplyr)
> custom_bins <- c(300, 350, 400, 450)
> mutate(data.frame(x = 397:403), fct_elevation_2 = cut(x, breaks = custom_bins))
    x fct_elevation_2
1 397       (350,400]
2 398       (350,400]
3 399       (350,400]
4 400       (350,400]
5 401       (400,450]
6 402       (400,450]
7 403       (400,450]
```
Regards, 
Klaus

