### PR TITLE
Simplify summarize() call into just count()

### DIFF
--- a/_episodes_rmd/02-raster-plot.Rmd
+++ b/_episodes_rmd/02-raster-plot.Rmd
@@ -72,7 +72,7 @@ unique(DSM_HARV_df$fct_elevation)
 ```
 
 And we can get the count of values in each group using `dplyr`'s 
-`group_by()` and `summarize()` functions:
+`group_by()` and `count()` functions:
 
 ```{r breaks-count}
 DSM_HARV_df %>%
@@ -113,7 +113,7 @@ And we can get the count of values in each group in the same way we did before:
 ```{r break-count-custom}
 DSM_HARV_df %>%
   group_by(fct_elevation_2) %>%
-  summarize(counts = n())
+  count()
 ```
 
 We can use those groups to plot our raster data, with each group being a different color:

--- a/_episodes_rmd/02-raster-plot.Rmd
+++ b/_episodes_rmd/02-raster-plot.Rmd
@@ -77,7 +77,7 @@ And we can get the count of values in each group using `dplyr`'s
 ```{r breaks-count}
 DSM_HARV_df %>%
         group_by(fct_elevation) %>%
-        summarize(counts = n())
+        count()
 ```
 
 We might prefer to customize the cutoff values for these groups.


### PR DESCRIPTION
This is a more straightforward way of doing this, and minimizes the amount of new syntax that learners see