### PR TITLE
Fix undefined `CHM_HARV_sp` variable

### DIFF
--- a/_episodes_rmd/11-vector-raster-integration.Rmd
+++ b/_episodes_rmd/11-vector-raster-integration.Rmd
@@ -149,7 +149,7 @@ coordinates into a polygon that we can plot:
 CHM_HARV_Cropped_df <- as.data.frame(CHM_HARV_Cropped, xy = TRUE)
 
 ggplot() +
-  geom_sf(data = st_as_sfc(st_bbox(CHM_HARV_sp)), fill = "green",
+  geom_sf(data = st_as_sfc(st_bbox(CHM_HARV)), fill = "green",
           color = "green", alpha = .2) +  
   geom_raster(data = CHM_HARV_Cropped_df,
               aes(x = x, y = y, fill = HARV_chmCrop)) + 


### PR DESCRIPTION
Code at Although `CHM_HARV_sp` is defined in hidden code, it seems that the code in the text (line 152) meant to use `CHM_HARV` .  Doesn't run as-is because learners haven't defined `CHM_HARV_sp`.
