### PR TITLE
Remove extra code in example that doesn't produce correct output

### DIFF
--- a/_episodes_rmd/03-raster-reproject-in-r.Rmd
+++ b/_episodes_rmd/03-raster-reproject-in-r.Rmd
@@ -77,18 +77,13 @@ Now we can create a map of the DTM layered over the hillshade.
 
 ```{r}
 ggplot() +
+     geom_raster(data = DTM_HARV_df , 
+                 aes(x = x, y = y, 
+                  fill = HARV_dtmCrop)) + 
      geom_raster(data = DTM_hill_HARV_df, 
                  aes(x = x, y = y, 
-                   alpha = HARV_DTMhill_WGS84)
-                 ) +
-     geom_raster(data = DTM_HARV_df , 
-             aes(x = x, y = y, 
-                  fill = HARV_dtmCrop,
-                  alpha=0.8)
-             ) + 
-     scale_fill_gradientn(name = "Elevation", colors = terrain.colors(10)) +
-     guides(fill = guide_colorbar()) +
-     scale_alpha(range = c(0.25, 0.65), guide = "none") +
+                   alpha = HARV_DTMhill_WGS84)) +
+     scale_fill_gradientn(name = "Elevation", colors = terrain.colors(10)) + 
      coord_quickmap()
 ```
 


### PR DESCRIPTION
@rbavery and I taught a workshop with this lesson this week.

We found that the learners spent several minutes trying to type up this block of code, and double check parentheses and so on, only to find that the code example doesn't work.

I tried to remove unnecessary lines to get a minimal example that "should" work but doesn't, because of the resolution and projection.

It should also match the code for the final plot that is made after the res and crs fixes.