### PR TITLE
Critical: solution to challenge 1 in "Explore and Plot by Shapefile Attributes" is wrong

### DIFF
--- a/_episodes_rmd/07-vector-shapefile-attributes-in-r.Rmd
+++ b/_episodes_rmd/07-vector-shapefile-attributes-in-r.Rmd
@@ -429,7 +429,7 @@ ggplot() +
 > > Next, we will create a new object `lines_removeNA` that removes missing values.
 > >
 > > ```{r}
-> > lines_removeNA <- lines_HARV[na.omit(lines_HARV$BicyclesHo),]
+> > lines_removeNA <- lines_HARV[!is.na(lines_HARV$BicyclesHo),] 
 > > ```
 > >
 > > In our plot, we will set colors so that only the allowed roads
@@ -437,9 +437,13 @@ ggplot() +
 > > factor level is thicker than the others.
 > >
 > > ```{r harv-paths-bike-horses}
+> > # First, create a data frame with only those roads where bicycles and horses are allowed
+> > lines_showHarv <- lines_removeNA %>% filter(BicyclesHo == "Bicycles and Horses Allowed")
+> >
+> > # Next, visualise using ggplot
 > > ggplot() + 
 > >   geom_sf(data = lines_HARV) + 
-> >   geom_sf(data = lines_removeNA, aes(color = BicyclesHo), size = 2) + 
+> >   geom_sf(data = lines_showHarv, aes(color = BicyclesHo), size = 2) + 
 > >   scale_color_manual(values = "magenta") +
 > >   ggtitle("NEON Harvard Forest Field Site", subtitle = "Roads Where Bikes and Horses Are Allowed") + 
 > >   coord_sf()


### PR DESCRIPTION
There is an error in the solution, thanks to R's attempts to be helpful for us when working with na.omit with a factor variable. 
I explain the error below, and have fixed it (in as concise code as possible) above, in the pull request

----------
## Explanation for error:

If we look at lines_HARV$BicyclesHo:
```
lines_HARV$BicyclesHo
 [1] Bicycles and Horses Allowed     Bicycles and Horses Allowed     Bicycles and Horses Allowed    
 [4] <NA>                            <NA>                            <NA>                           
 [7] <NA>                            <NA>                            <NA>                           
[10] DO NOT SHOW ON REC MAP          Bicycles and Horses Allowed     Bicycles and Horses NOT ALLOWED
[13] Bicycles and Horses Allowed    
Levels: Bicycles and Horses Allowed Bicycles and Horses NOT ALLOWED DO NOT SHOW ON REC MAP
```
We can see that 
- 1,2,3,11,13 are "Bicycles and Horses Allowed", factor level 1
- 4,5,6,7,8,9,  are NA
- 12 is "Bicycles and Horses NOT ALLOWED", factor level 2
- 10 is "DO NOT SHOW ON REC MAP", factor level 3

If you then follow the instructions in the course, and use na.omit:
```
# Next, we will create a new object `lines_removeNA` that removes missing values.
lines_removeNA <- lines_HARV[na.omit(lines_HARV$BicyclesHo),]
```
Let's have a look at what na.omit actually does:

```na.omit(lines_HARV$BicyclesHo)``` actually produces the following output, which looks OK at first glance:

```
[1] Bicycles and Horses Allowed     Bicycles and Horses Allowed     Bicycles and Horses Allowed     DO NOT SHOW ON REC MAP         
[5] Bicycles and Horses Allowed     Bicycles and Horses NOT ALLOWED Bicycles and Horses Allowed    
attr(,"na.action")
[1] 4 5 6 7 8 9
attr(,"class")
[1] omit
Levels: Bicycles and Horses Allowed Bicycles and Horses NOT ALLOWED DO NOT SHOW ON REC MAP
```
We'd hope that as.numeric(na.omit(...)) would give us the values in na.action - but what happens instead is this:
```
as.numeric(na.omit(lines_HARV$BicyclesHo))
[1] 1 1 1 3 1 2 1
```
It gives us the values that correspond to the factor levels of the non-NA values in the na.omit output! This is why the plot ends up being incorrect - it's only plotting the first three values of our lines_HARV dataframe, and these are pentaplicated, in the case of "48	woods road	Locust Opening Rd"!:

```
head(lines_removeNA)
    OBJECTID_1 OBJECTID       TYPE             NOTES MISCNOTES RULEID          MAPLABEL SHAPE_LENG             LABEL BIKEHORSE RESVEHICLE
1           14       48 woods road Locust Opening Rd      <NA>      5 Locust Opening Rd  1297.3571 Locust Opening Rd         Y         R1
1.1         14       48 woods road Locust Opening Rd      <NA>      5 Locust Opening Rd  1297.3571 Locust Opening Rd         Y         R1
1.2         14       48 woods road Locust Opening Rd      <NA>      5 Locust Opening Rd  1297.3571 Locust Opening Rd         Y         R1
3           41      106   footpath              <NA>      <NA>      6              <NA>   676.7180              <NA>         Y         R2
1.3         14       48 woods road Locust Opening Rd      <NA>      5 Locust Opening Rd  1297.3571 Locust Opening Rd         Y         R1
2           40       91   footpath              <NA>      <NA>      6              <NA>   146.2998              <NA>         Y         R1
    RECMAP Shape_Le_1                            ResVehic_1                  BicyclesHo                       geometry
1        Y  1297.1062    R1 - All Research Vehicles Allowed Bicycles and Horses Allowed MULTILINESTRING ((730819.2 ...
1.1      Y  1297.1062    R1 - All Research Vehicles Allowed Bicycles and Horses Allowed MULTILINESTRING ((730819.2 ...
1.2      Y  1297.1062    R1 - All Research Vehicles Allowed Bicycles and Horses Allowed MULTILINESTRING ((730819.2 ...
3        Y   676.7181 R2 - 4WD/High Clearance Vehicles Only Bicycles and Horses Allowed MULTILINESTRING ((732057 47...
1.3      Y  1297.1062    R1 - All Research Vehicles Allowed Bicycles and Horses Allowed MULTILINESTRING ((730819.2 ...
2        Y   146.2998    R1 - All Research Vehicles Allowed Bicycles and Horses Allowed MULTILINESTRING ((732040.2 ...
```
