### PR TITLE
ep. 11: results="hide" when loading sf data

### DIFF
--- a/_episodes_rmd/11-vector-raster-integration.Rmd
+++ b/_episodes_rmd/11-vector-raster-integration.Rmd
@@ -80,7 +80,7 @@ we have worked with in this workshop:
 * Vegetation plot locations (marked with white dots)-- black
 * A canopy height model (CHM) in GeoTIFF format -- green
 
-```{r view-extents, echo = FALSE}
+```{r view-extents, echo = FALSE, results='hide'}
 # code not shown, for demonstration purposes only
 # create CHM as a shapefile
 CHM_HARV_sp <- st_as_sf(CHM_HARV_df, coords = c("x", "y"), crs = utm18nCRS)


### PR DESCRIPTION
In episode 11 (Manipulate Raster Data in R), a couple shapefiles are loaded in a hidden code chunk to product a map, however, the output of `st_read()` is visible in the lesson, confusingly without any associated code. Use results="hide" in code chunk so this doesn't appear.