### PR TITLE
No need to convert to sp prior to crop

### DIFF
--- a/_episodes_rmd/11-vector-raster-integration.Rmd
+++ b/_episodes_rmd/11-vector-raster-integration.Rmd
@@ -296,7 +296,7 @@ Forest field site.
 
 ```{r extract-from-raster}
 tree_height <- extract(x = CHM_HARV,
-                       y = as(aoi_boundary_HARV, "Spatial"),
+                       y = aoi_boundary_HARV,
                        df = TRUE)
 
 str(tree_height)

--- a/_episodes_rmd/11-vector-raster-integration.Rmd
+++ b/_episodes_rmd/11-vector-raster-integration.Rmd
@@ -194,7 +194,7 @@ Canopy Height Model information.
 > > 
 > > ```{r challenge-code-crop-raster-points}
 > > 
-> > CHM_plots_HARVcrop <- crop(x = CHM_HARV, y = as(plot_locations_sp_HARV, "Spatial"))
+> > CHM_plots_HARVcrop <- crop(x = CHM_HARV, y = plot_locations_sp_HARV)
 > > 
 > > CHM_plots_HARVcrop_df <- as.data.frame(CHM_plots_HARVcrop, xy = TRUE)
 > > 
@@ -383,10 +383,10 @@ mean_tree_height_tower
 > > ```{r hist-tree-height-veg-plot}
 > > # extract data at each plot location
 > > mean_tree_height_plots_HARV <- extract(x = CHM_HARV,
-> >                                 y = as(plot_locations_sp_HARV, "Spatial"),
-> >                                buffer=20,
-> >                                fun = mean,
-> >                                df = TRUE)
+> >                                        y = plot_locations_sp_HARV,
+> >                                        buffer = 20,
+> >                                        fun = mean,
+> >                                        df = TRUE)
 > > 
 > > # view data
 > > mean_tree_height_plots_HARV

--- a/_episodes_rmd/11-vector-raster-integration.Rmd
+++ b/_episodes_rmd/11-vector-raster-integration.Rmd
@@ -295,9 +295,7 @@ We will begin by extracting all canopy height pixel values located within our
 Forest field site.
 
 ```{r extract-from-raster}
-tree_height <- extract(x = CHM_HARV,
-                       y = aoi_boundary_HARV,
-                       df = TRUE)
+tree_height <- extract(x = CHM_HARV, y = aoi_boundary_HARV, df = TRUE)
 
 str(tree_height)
 ```
@@ -337,9 +335,7 @@ a mean height value for our AOI. Because we are extracting only a single number,
 not use the `df = TRUE` argument. 
 
 ```{r summarize-extract }
-mean_tree_height_AOI <- extract(x = CHM_HARV,
-                              y = as(aoi_boundary_HARV, "Spatial"),
-                              fun = mean)
+mean_tree_height_AOI <- extract(x = CHM_HARV, y = aoi_boundary_HARV, fun = mean)
 
 mean_tree_height_AOI
 ```
@@ -365,7 +361,7 @@ will not use the `df = TRUE` argument.
 
 ```{r extract-point-to-buffer }
 mean_tree_height_tower <- extract(x = CHM_HARV,
-                                  y = as(point_HARV, "Spatial"),
+                                  y = point_HARV,
                                   buffer = 20,
                                   fun = mean)
 

--- a/_episodes_rmd/11-vector-raster-integration.Rmd
+++ b/_episodes_rmd/11-vector-raster-integration.Rmd
@@ -131,11 +131,12 @@ ggplot() +
 ```
 
 Now that we have visualized the area of the CHM we want to subset, we can
-perform the cropping operation. We are going to create a new object with only
-the portion of the CHM data that falls within the boundaries of the AOI. The function `crop()` is from the raster package and doesn't know how to deal with `sf` objects. Therefore, we first need to convert `aoi_boundary_HARV` from a `sf` object to "Spatial" object.
+perform the cropping operation. We are going to `crop()` function from the 
+raster package to create a new object with only the portion of the CHM data 
+that falls within the boundaries of the AOI.
 
 ```{r}
-CHM_HARV_Cropped <- crop(x = CHM_HARV, y = as(aoi_boundary_HARV, "Spatial"))
+CHM_HARV_Cropped <- crop(x = CHM_HARV, y = aoi_boundary_HARV)
 ```
 
 Now we can plot the cropped CHM data, along with a boundary box showing the full


### PR DESCRIPTION
Most raster package functions now handle sf objects without need for conversion to sp objects explicitly.