### PR TITLE
Update 07-vector-shapefile-attributes-in-r.Rmd

### DIFF
--- a/_episodes_rmd/07-vector-shapefile-attributes-in-r.Rmd
+++ b/_episodes_rmd/07-vector-shapefile-attributes-in-r.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Explore and Plot by Shapefile Attributes"
+title: "Explore and Plot by Vector Feature Attributes"
 teaching: 40
 exercises: 20
 questions:
@@ -7,7 +7,7 @@ questions:
 objectives:
 - "Query attributes of a spatial object."
 - "Subset spatial objects using specific attribute values."
-- "Plot a shapefile, colored by unique attribute values."
+- "Plot a simple feature, colored by unique attribute values."
 keypoints:
 - "Spatial objects in `sf` are similar to standard data frames and can be manipulated using the same functions."
 - "Almost any feature of a plot can be customized using the various functions and options in the `ggplot2` package."
@@ -41,19 +41,19 @@ aoi_boundary_HARV <- st_read(
 > data, and other prerequisites you will need to work through the examples in this episode.
 {: .prereq}
 
-This episode continues our discussion of shapefile attributes and 
-covers how to work with shapefile attributes in R. It covers how
-to identify and query shapefile
-attributes, as well as how to subset shapefiles by specific attribute values.
-Finally, we will learn how to plot a shapefile according to a set of attribute
+This episode continues our discussion of vector feature attributes and 
+covers how to work with vector feature attributes in R. It covers how
+to identify and query simple feature
+attributes, as well as how to subset features by specific attribute values.
+Finally, we will learn how to plot a feature according to a set of attribute
 values.
 
 ## Load the Data
 We will continue using the `sf`, `raster` and `ggplot2` packages in this episode. Make sure that you have these packages loaded. We will
-continue to work with the three shapefiles that we loaded in the
+continue to work with the three shapefiles (vector features) that we loaded in the
 [Open and Plot Shapefiles in R]({{site.baseurl}}/06-vector-open-shapefile-in-r/) episode.
 
-## Query Shapefile Metadata
+## Query Vector Feature Metadata
 
 As we discussed in the
 [Open and Plot Shapefiles in R]({{site.baseurl}}/06-vector-open-shapefile-in-r/) episode,
@@ -127,7 +127,7 @@ We can explore individual values stored within a particular attribute.
 Comparing attributes to a spreadsheet or a data frame, this is similar
 to exploring values in a column. We did this with the `gapminder` dataframe in [an earlier lesson](https://datacarpentry.org/r-intro-geospatial/05-data-subsetting/index.html). For spatial objects, we can use the same syntax: `objectName$attributeName`.
 
-We can see the contents of the `TYPE` field of our lines shapefile:
+We can see the contents of the `TYPE` field of our lines feature:
 
 ```{r explore-attribute-values }
 lines_HARV$TYPE
@@ -142,7 +142,7 @@ within R is factor. We worked with factors a little bit in [an earlier lesson](h
 levels(lines_HARV$TYPE)
 ```
 
-### Subset Shapefiles
+### Subset Features
 We can use the `filter()` function from `dplyr` that we worked with in [an earlier lesson](https://datacarpentry.org/r-intro-geospatial/06-dplyr) to select a subset of features
 from a spatial object in R, just like with data frames.
 

--- a/_episodes_rmd/07-vector-shapefile-attributes-in-r.Rmd
+++ b/_episodes_rmd/07-vector-shapefile-attributes-in-r.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Explore and Plot by Vector Feature Attributes"
+title: "Explore and Plot by Vector Layer Attributes"
 teaching: 40
 exercises: 20
 questions:
@@ -41,16 +41,16 @@ aoi_boundary_HARV <- st_read(
 > data, and other prerequisites you will need to work through the examples in this episode.
 {: .prereq}
 
-This episode continues our discussion of vector feature attributes and 
-covers how to work with vector feature attributes in R. It covers how
-to identify and query simple feature
+This episode continues our discussion of vector layer attributes and 
+covers how to work with vector layer attributes in R. It covers how
+to identify and query simple layer
 attributes, as well as how to subset features by specific attribute values.
 Finally, we will learn how to plot a feature according to a set of attribute
 values.
 
 ## Load the Data
 We will continue using the `sf`, `raster` and `ggplot2` packages in this episode. Make sure that you have these packages loaded. We will
-continue to work with the three shapefiles (vector features) that we loaded in the
+continue to work with the three shapefiles (vector layers) that we loaded in the
 [Open and Plot Shapefiles in R]({{site.baseurl}}/06-vector-open-shapefile-in-r/) episode.
 
 ## Query Vector Feature Metadata
@@ -253,7 +253,7 @@ First we will check how many unique levels our factor has:
 levels(lines_HARV$TYPE)
 ```
 
-Then we can create a pallet of four colors, one for each
+Then we can create a palette of four colors, one for each
 feature in our vector object.
 
 ```{r}


### PR DESCRIPTION
Per issue #312 (https://github.com/datacarpentry/r-raster-vector-geospatial/issues/312) lessons should start to move away from using the term shapefile as being synonymous to vector data. In this pull request I have changed places that say shapefile with either vector feature or feature.   

This is my first contribution and is for my Instructor Training checkout.
