### PR TITLE
use bionic over trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ after_script: R -q -e 'tic::after_script()'
 # Header
 language: r
 sudo: false
-dist: trusty
+dist: bionic
 cache: packages
 latex: false
 


### PR DESCRIPTION
based on this: https://travis-ci.org/github/datacarpentry/r-intro-geospatial/jobs/704467768#L946-L947 it seems that trusty is no longer supported by the PPA. I'm trying to see if bionic will work
