### PR TITLE
🔗🖼 Changed relative images links to "absolutes"

### DIFF
--- a/_episodes_rmd/01-raster-structure.Rmd
+++ b/_episodes_rmd/01-raster-structure.Rmd
@@ -227,7 +227,7 @@ the data is WGS84
 Note that the zone is unique to the UTM projection. Not all CRSs will have a
 zone. Image source: Chrismurf at English Wikipedia, via [Wikimedia Commons](https://en.wikipedia.org/wiki/Universal_Transverse_Mercator_coordinate_system#/media/File:Utm-zones-USA.svg) (CC-BY).
 
-![The UTM zones across the continental United States. From: https://upload.wikimedia.org/wikipedia/commons/8/8d/Utm-zones-USA.svg](../images/Utm-zones-USA.svg)
+![The UTM zones across the continental United States. From: https://upload.wikimedia.org/wikipedia/commons/8/8d/Utm-zones-USA.svg]({{ site.baseurl }}/images/Utm-zones-USA.svg)
 
 ## Calculate Raster Min and Max Values
 
@@ -262,7 +262,7 @@ The Digital Surface Model object (`DSM_HARV`) that we've been working with is a
 single band raster. This means that there is only one dataset stored in the
 raster: surface elevation in meters for one time period.
 
-![Multi-band raster image](../images/dc-spatial-raster/single_multi_raster.png)
+![Multi-band raster image]({{ site.baseurl }}/images/dc-spatial-raster/single_multi_raster.png)
 
 A raster dataset can contain one or more bands. We can use the `raster()`
 function to import one single band from a single or multi-band raster. We can

--- a/_episodes_rmd/03-raster-reproject-in-r.Rmd
+++ b/_episodes_rmd/03-raster-reproject-in-r.Rmd
@@ -54,7 +54,7 @@ DSM and DTM. Here, we will create a map of the Harvard Forest Digital
 Terrain Model
 (`DTM_HARV`) draped or layered on top of the hillshade (`DTM_hill_HARV`).
 
-![Source: National Ecological Observatory Network (NEON).](../images/dc-spatial-raster/lidarTree-height.png)
+![Source: National Ecological Observatory Network (NEON).]({{ site.baseurl }}/images/dc-spatial-raster/lidarTree-height.png)
 
 First, we need to import the DTM and DTM hillshade data.
 

--- a/_episodes_rmd/04-raster-calculations-in-r.Rmd
+++ b/_episodes_rmd/04-raster-calculations-in-r.Rmd
@@ -71,7 +71,7 @@ Digital Terrain Model (DTM, ground level). The resulting dataset is referred to
 as a Canopy Height Model (CHM) and represents the actual height of trees,
 buildings, etc. with the influence of ground elevation removed.
 
-![Source: National Ecological Observatory Network (NEON)](../images/dc-spatial-raster/lidarTree-height.png) 
+![Source: National Ecological Observatory Network (NEON)]({{ site.baseurl }}/images/dc-spatial-raster/lidarTree-height.png) 
 
 > ## More Resources
 > * Check out more on LiDAR CHM, DTM and DSM in this NEON Data Skills overview tutorial:

--- a/_episodes_rmd/05-raster-multi-band-in-r.Rmd
+++ b/_episodes_rmd/05-raster-multi-band-in-r.Rmd
@@ -226,12 +226,12 @@ The image above looks pretty good. We can explore whether applying a stretch to
 the image might improve clarity and contrast using `stretch="lin"` or
 `stretch="hist"`.
 
-![Image Stretch](../images/dc-spatial-raster/imageStretch_dark.jpg)
+![Image Stretch]({{ site.baseurl }}/images/dc-spatial-raster/imageStretch_dark.jpg)
 
 When the range of pixel brightness values is closer to 0, a darker image is rendered by default. We can stretch 
 the values to extend to the full 0-255 range of potential values to increase the visual contrast of the image.
 
-![Image Stretch light](../images/dc-spatial-raster/imageStretch_light.jpg)
+![Image Stretch light]({{ site.baseurl }}/images/dc-spatial-raster/imageStretch_light.jpg)
 
 When the range of pixel brightness values is closer to 255, a
 lighter image is rendered by default. We can stretch the values to extend to

--- a/_episodes_rmd/06-vector-open-shapefile-in-r.Rmd
+++ b/_episodes_rmd/06-vector-open-shapefile-in-r.Rmd
@@ -117,7 +117,7 @@ st_bbox(aoi_boundary_HARV)
 
 The spatial extent of a shapefile or R spatial object represents the geographic "edge" or location that is the furthest north, south east and west. Thus is represents the overall geographic coverage of the spatial object. Image Source: National Ecological Observatory Network (NEON).
 
-![Extent image](../images/dc-spatial-vector/spatial_extent.png)
+![Extent image]({{ site.baseurl }}/images/dc-spatial-vector/spatial_extent.png)
 
 Lastly, we can view all of the metadata and attributes for this shapefile object
 by printing it to the screen:

--- a/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
+++ b/_episodes_rmd/09-vector-when-data-dont-line-up-crs.Rmd
@@ -69,7 +69,7 @@ provider (for example, a government agency).
 For instance, many states in the US prefer to use a State Plane projection customized
 for that state.
 
-![Maps of the United States using data in different projections. Source: opennews.org, from: https://media.opennews.org/cache/06/37/0637aa2541b31f526ad44f7cb2db7b6c.jpg](../images/map_usa_different_projections.jpg)
+![Maps of the United States using data in different projections. Source: opennews.org, from: https://media.opennews.org/cache/06/37/0637aa2541b31f526ad44f7cb2db7b6c.jpg]({{ site.baseurl }}/images/map_usa_different_projections.jpg)
 
 Notice the differences in shape associated with each different
 projection. These differences are a direct result of the calculations

--- a/_episodes_rmd/11-vector-raster-integration.Rmd
+++ b/_episodes_rmd/11-vector-raster-integration.Rmd
@@ -69,7 +69,7 @@ spatial extent of a shapefile or R spatial object represents the geographic
 "edge" or location that is the furthest north, south east and west. Thus is
 represents the overall geographic coverage of the spatial object.
 
-![Extent illustration](../images/dc-spatial-vector/spatial_extent.png) Image Source: National
+![Extent illustration]({{ site.baseurl }}/images/dc-spatial-vector/spatial_extent.png) Image Source: National
 Ecological Observatory Network (NEON)
 
 The graphic below illustrates the extent of several of the spatial layers that
@@ -279,7 +279,7 @@ ggplot() +
 Often we want to extract values from a raster layer for particular locations -
 for example, plot locations that we are sampling on the ground. We can extract all pixel values within 20m of our x,y point of interest. These can then be summarized into some value of interest (e.g. mean, maximum, total).
 
-![Extract raster information using a polygon boundary. From https://www.neonscience.org/sites/default/files/images/spatialData/BufferSquare.png](../images//BufferSquare.png)
+![Extract raster information using a polygon boundary. From https://www.neonscience.org/sites/default/files/images/spatialData/BufferSquare.png]({{ site.baseurl }}/images//BufferSquare.png)
 
 To do this in R, we use the `extract()` function. The `extract()` function
 requires:
@@ -351,7 +351,7 @@ we define the summary argument (`fun = mean`) and the buffer distance (`buffer =
 which represents the radius of a circular region around each point. By default, the units of the
 buffer are the same units as the data's CRS. All pixels that are touched by the buffer region are included in the extract.
 
-![Extract raster information using a buffer region. From: https://www.neonscience.org/sites/default/files/images/spatialData/BufferCircular.png](../images/BufferCircular.png)
+![Extract raster information using a buffer region. From: https://www.neonscience.org/sites/default/files/images/spatialData/BufferCircular.png]({{ site.baseurl }}/images/BufferCircular.png)
 
 Source: National Ecological Observatory Network (NEON).
 

--- a/_episodes_rmd/12-time-series-raster.Rmd
+++ b/_episodes_rmd/12-time-series-raster.Rmd
@@ -129,7 +129,7 @@ CRS is in UTM Zone 19. If you have completed the previous episodes in
 this workshop, you may have noticed that the UTM zone for the NEON collected remote sensing
 data was in Zone 18 rather than Zone 19. Why are the Landsat data in Zone 19?
 
-![Source: National Ecological Observatory Network (NEON).](../images/dc-spatial-raster/UTM_zones_18-19.jpg)
+![Source: National Ecological Observatory Network (NEON).]({{ site.baseurl }}/images/dc-spatial-raster/UTM_zones_18-19.jpg)
 
 A Landsat scene is extremely wide - spanning over 170km north to
 south and 180km east to west. This means that Landsat data often cover multiple

--- a/bin/chunk-options.R
+++ b/bin/chunk-options.R
@@ -6,7 +6,7 @@
 
 library("knitr")
 
-fix_fig_path <- function(pth) file.path("..", pth)
+fix_fig_path <- function(pth) file.path("{{ site.baseurl }}", pth)
 
 
 ## We set the path for the figures globally below, so if we want to


### PR DESCRIPTION
This is needed for the translations as otherwise the image links need to be
also "translated" to a different location.

Note that this still should work for the English as it's shown on [the translations themed page for r-intro-geospatial](https://carpentries-i18n.github.io/r-intro-geospatial/01-rstudio-intro/index.html).

I have also modified the R code that sets the path for the auto-generated plots.

(same changes as in datacarpentry/r-intro-geospatial#80)