### PR TITLE
Definition of DTM and DSM + hillshade

### DIFF
--- a/_episodes_rmd/03-raster-reproject-in-r.Rmd
+++ b/_episodes_rmd/03-raster-reproject-in-r.Rmd
@@ -45,14 +45,16 @@ happens when things don't line up?
 
 For this episode, we will be working with the Harvard Forest Digital Terrain
 Model data. This differs from the surface model data we've been working with so
-far in that the digital terrain model (DTM) includes the tops of trees, while
-the digital surface model (DSM) shows the ground level.
+far in that the digital surface model (DSM) includes the tops of trees, while
+the digital terrain model (DTM) shows the ground level.
 
 We'll be looking at another model (the canopy height model) in
 [a later episode]({{ site.baseurl }}/04-raster-calculations-in-r/) and will see how to calculate the CHM from the
 DSM and DTM. Here, we will create a map of the Harvard Forest Digital
 Terrain Model
-(`DTM_HARV`) draped or layered on top of the hillshade (`DTM_hill_HARV`).
+(`DTM_HARV`) draped or layered on top of the hillshade (`DTM_hill_HARV`). 
+The hillshade layer maps the terrain using light and shadow to create a 3D-looking image, 
+based on a hypothetical illumination of the ground level.
 
 ![Source: National Ecological Observatory Network (NEON).](../images/dc-spatial-raster/lidarTree-height.png)
 


### PR DESCRIPTION
In the introduction of the episode (Section: Raster Projection in R), the definitions of DTM and DSM do not match the ones on the figure. I'm correcting them to be consistent with GIS theory. I'm also adding a short definition of "hillshade". 
This contribution was previously discussed on an issue:  https://github.com/datacarpentry/r-raster-vector-geospatial/issues/331

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
