### PR TITLE
Fix broken link from https://datacarpentry.org/lessons/

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -1,6 +1,5 @@
 ---
 layout: reference
-permalink: /reference/
 ---
 
 ## References


### PR DESCRIPTION
Discussion in https://github.com/datacarpentry/datacarpentry.github.io/pull/531 identified a problem with broken links from https://datacarpentry.org/lessons/ to the reference and/or instructor notes pages for some lessons. This PR fixes the problem for the Reference page of this lesson, by unsetting the permalink on `reference.md`.