### PR TITLE
fix challenge errors due to color = NA in geom_sf()

### DIFF
--- a/_episodes_rmd/08-vector-plot-shapefiles-custom-legend.Rmd
+++ b/_episodes_rmd/08-vector-plot-shapefiles-custom-legend.Rmd
@@ -159,7 +159,7 @@ symbol of `shape` value.
 > > each soil type.
 > >
 > > ```{r}
-> > blue_green <- c("blue", "darkgreen")
+> > blue_orange <- c("cornflowerblue", "darkorange")
 > > ```
 > >
 > > Finally, we will create our plot.
@@ -168,10 +168,10 @@ symbol of `shape` value.
 > > ggplot() + 
 > >   geom_sf(data = lines_HARV, aes(color = TYPE), show.legend = "line") + 
 > >   geom_sf(data = plot_locations, aes(fill = soilTypeOr), 
-> >           shape = 21, color = NA, show.legend = 'point') + 
+> >           shape = 21, show.legend = 'point') + 
 > >   scale_color_manual(name = "Line Type", values = road_colors,
 > >      guide = guide_legend(override.aes = list(linetype = "solid", shape = NA))) + 
-> >   scale_fill_manual(name = "Soil Type", values = blue_green,
+> >   scale_fill_manual(name = "Soil Type", values = blue_orange,
 > >      guide = guide_legend(override.aes = list(linetype = "blank", shape = 21, colour = NA))) + 
 > >   ggtitle("NEON Harvard Forest Field Site") + 
 > >   coord_sf()
@@ -184,13 +184,13 @@ symbol of `shape` value.
 > > ggplot() + 
 > >   geom_sf(data = lines_HARV, aes(color = TYPE), show.legend = "line", size = 1) + 
 > >   geom_sf(data = plot_locations, aes(fill = soilTypeOr, shape = soilTypeOr),
-> >           show.legend = 'point', colour = NA, size = 3) + 
+> >           show.legend = 'point', size = 3) + 
 > >   scale_shape_manual(name = "Soil Type", values = c(21, 22)) +
 > >   scale_color_manual(name = "Line Type", values = road_colors,
 > >      guide = guide_legend(override.aes = list(linetype = "solid", shape = NA))) + 
-> >   scale_fill_manual(name = "Soil Type", values = blue_green,
+> >   scale_fill_manual(name = "Soil Type", values = blue_orange,
 > >      guide = guide_legend(override.aes = list(linetype = "blank", shape = c(21, 22),
-> >      color = blue_green))) + 
+> >      color = blue_orange))) + 
 > >   ggtitle("NEON Harvard Forest Field Site") + 
 > >   coord_sf()
 > > ```


### PR DESCRIPTION
This PR fixes the error in the second to last challenge of episode 8, which currently fails due to the use of `colour = NA` in `geom_sf()`, documented this error in #351. The modified R code all runs correctly on my machine, but I was unable to fully knit the `.Rmd` file, I'm guessing due to some knitr path issues/differences from the CI pipeline used to render the episode website.

While removing `colour = NA` reintroduces the black border on the dots, I've changed the dot fill scheme from blue and green to blue and orange to better distinguish between the two while the black border is present.