### PR TITLE
Correct name for UTM coordinates

### DIFF
--- a/_episodes_rmd/02-raster-plot.Rmd
+++ b/_episodes_rmd/02-raster-plot.Rmd
@@ -203,7 +203,7 @@ ggplot() +
 > >                                       fill = fct_elevation_6)) + 
 > >     scale_fill_manual(values = my_col, name = "Elevation") + 
 > >     ggtitle("Classified Elevation Map - NEON Harvard Forest Field Site") +
-> >     xlab("UTM Westing Coordinate (m)") +
+> >     xlab("UTM Easting Coordinate (m)") +
 > >     ylab("UTM Northing Coordinate (m)") + 
 > >     coord_quickmap()
 > > ```

--- a/_episodes_rmd/02-raster-plot.Rmd
+++ b/_episodes_rmd/02-raster-plot.Rmd
@@ -318,7 +318,7 @@ Range field site.
 > >     theme_bw() + 
 > >     theme(panel.grid.major = element_blank(), 
 > >           panel.grid.minor = element_blank()) +
-> >     xlab("UTM Westing Coordinate (m)") +
+> >     xlab("UTM Easting Coordinate (m)") +
 > >     ylab("UTM Northing Coordinate (m)") +
 > >     ggtitle("DSM with Hillshade") +
 > >     coord_quickmap()


### PR DESCRIPTION
X coordinates in UTM projections are known as eastings. This patch renames axis labels from 'Westing' to 'Easting'
