### PR TITLE
towards workbench applicable readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Contributing to lesson development
 
 - The lesson files to be edited are in the `_episodes` folder. This repository uses the `main` branch for development.
-- You can visualize the changes locally with the [sandpaper](https://github.com/carpentries/sandpaper) R package by executing either the `sandpaper::serve()` or `sandpaper::build_lesson()` commands. In the former case, the site will be rendered at [http://localhost:4000](http://localhost:4000)
+- You can visualize the changes locally with the [sandpaper](https://github.com/carpentries/sandpaper) R package by executing either the `sandpaper::serve()` or `sandpaper::build_lesson()` commands. In the former case, the site will be rendered at [http://localhost:4321](http://localhost:4321)
 - Each time you push a change to GitHub, Github Actions rebuilds the lesson, and when it's successful (look for the green badge at the top of the README file), it publishes the result at [http://www.datacarpentry.org/r-raster-vector-geospatial/](http://www.datacarpentry.org/r-raster-vector-geospatial/)
 - Note: any manual commit to `gh-pages` will be erased and lost during the automated build and deploy cycle operated by Github Actions.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Contributing to lesson development
 
 - The lesson files to be edited are in the `_episodes` folder. This repository uses the `main` branch for development.
-- You can visualize the changes locally by typing `make serve` at your terminal. The site will be rendered at [http://localhost:4000](http://localhost:4000)
+- You can visualize the changes locally with the [sandpaper](https://github.com/carpentries/sandpaper) R package by executing either the `sandpaper::serve()` or `sandpaper::build_lesson()` commands. In the former case, the site will be rendered at [http://localhost:4000](http://localhost:4000)
 - Each time you push a change to GitHub, Github Actions rebuilds the lesson, and when it's successful (look for the green badge at the top of the README file), it publishes the result at [http://www.datacarpentry.org/r-raster-vector-geospatial/](http://www.datacarpentry.org/r-raster-vector-geospatial/)
 - Note: any manual commit to `gh-pages` will be erased and lost during the automated build and deploy cycle operated by Github Actions.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![DOI](https://zenodo.org/badge/44772343.svg)](https://zenodo.org/badge/latestdoi/44772343)
-[![Buildl and Deploy Website](https://github.com/datacarpentry/r-raster-vector-geospatial/actions/workflows/website.yml/badge.svg)](https://github.com/datacarpentry/r-raster-vector-geospatial/actions/workflows/website.yml)
+[![01 Build and Deploy Site](https://github.com/datacarpentry/r-raster-vector-geospatial/actions/workflows/sandpaper-main.yaml/badge.svg)](https://github.com/datacarpentry/r-raster-vector-geospatial/actions/workflows/sandpaper-main.yaml)
 [![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://swc-slack-invite.herokuapp.com/)
 [![Slack Status](https://img.shields.io/badge/Slack_Channel-dc--geospatial-E01563.svg)](https://swcarpentry.slack.com/messages/C9ME7G5RD)
 
@@ -7,12 +7,12 @@
 
 ## Contributing to lesson development
 
-- The lesson files to be edited are in the `_epiodes_rmd` folder. This repository uses the `main` branch for development.
+- The lesson files to be edited are in the `_episodes` folder. This repository uses the `main` branch for development.
 - You can visualize the changes locally by typing `make serve` at your terminal. The site will be rendered at [http://localhost:4000](http://localhost:4000)
-- Each time you push a change to GitHub, Travis-CI rebuilds the lesson, and when it's successful (look for the green badge at the top of the README file), it publishes the result at [http://www.datacarpentry.org/r-raster-vector-geospatial/](http://www.datacarpentry.org/r-raster-vector-geospatial/)
-- Note: any manual commit to `gh-pages` will be erased and lost during the automated build and deploy cycle operated by Travis-CI.
+- Each time you push a change to GitHub, Github Actions rebuilds the lesson, and when it's successful (look for the green badge at the top of the README file), it publishes the result at [http://www.datacarpentry.org/r-raster-vector-geospatial/](http://www.datacarpentry.org/r-raster-vector-geospatial/)
+- Note: any manual commit to `gh-pages` will be erased and lost during the automated build and deploy cycle operated by Github Actions.
 
-#### Lesson Maintainers:
+### Lesson Maintainers:
 
 - [Jemma Stachelek][stachelek_jemma]
 - [Ivo Arrey][arreyves]
@@ -20,6 +20,3 @@
 
 [stachelek_jemma]: https://carpentries.org/instructors/#jsta
 [arreyves]: https://carpentries.org/instructors/#arreyves
-
-
-


### PR DESCRIPTION
Trying to restyle the README for the new infrastructure.

@zkamvar Since there's no longer a Makefile, is the procedure for a local build to call `sandpaper::build_lesson`?