### PR TITLE
Issue # 312 to update the terms “shapefile”

### DIFF
--- a/episodes/06-vector-open-shapefile-in-r.Rmd
+++ b/episodes/06-vector-open-shapefile-in-r.Rmd
@@ -1,5 +1,5 @@
 ---
-title: Open and Plot Shapefiles
+title: Open and Plot Vector Layers
 teaching: 20
 exercises: 10
 source: Rmd
@@ -12,7 +12,7 @@ source("setup.R")
 ::::::::::::::::::::::::::::::::::::::: objectives
 
 - Know the difference between point, line, and polygon vector elements.
-- Load point, line, and polygon shapefiles into R.
+- Load point, line, and polygon vector layers into R.
 - Access the attributes of a spatial object in R.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -34,44 +34,44 @@ library(sf)
 
 ## Things You'll Need To Complete This Episode
 
-See the [lesson homepage](.) for detailed information about the software, data, 
-and other prerequisites you will need to work through the examples in this 
+See the [lesson homepage](.) for detailed information about the software, data,
+and other prerequisites you will need to work through the examples in this
 episode.
 
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-Starting with this episode, we will be moving from working with raster data to 
-working with vector data. In this episode, we will open and plot point, line 
-and polygon vector data stored in shapefile format in R. These data refer to 
-the 
-[NEON Harvard Forest field site](https://www.neonscience.org/field-sites/field-sites-map/HARV), 
-which we have been working with in previous episodes. In later episodes, we 
-will learn how to work with raster and vector data together and combine them 
+Starting with this episode, we will be moving from working with raster data to
+working with vector data. In this episode, we will open and plot point, line
+and polygon vector data loaded from ESRI's `shapefile` format into R. These data refer to
+the
+[NEON Harvard Forest field site](https://www.neonscience.org/field-sites/field-sites-map/HARV),
+which we have been working with in previous episodes. In later episodes, we
+will learn how to work with raster and vector data together and combine them
 into a single plot.
 
-## Import Shapefiles
+## Import Vector Data
 
-We will use the `sf` package to work with vector data in R. We will also use 
-the `terra` package, which has been loaded in previous episodes, so we can 
-explore raster and vector spatial metadata using similar commands. Make sure 
+We will use the `sf` package to work with vector data in R. We will also use
+the `terra` package, which has been loaded in previous episodes, so we can
+explore raster and vector spatial metadata using similar commands. Make sure
 you have the `sf` library loaded.
 
 ```{r load-sf, results="hide", eval=FALSE, message=FALSE}
 library(sf)
 ```
 
-The shapefiles that we will import are:
+The vector layers that we will import from ESRI's `shapefile` format are:
 
-- A polygon shapefile representing our field site boundary,
-- A line shapefile representing roads, and
-- A point shapefile representing the location of the [Fisher flux tower](https://www.neonscience.org/data-collection/flux-tower-measurements)
+- A polygon vector layer representing our field site boundary,
+- A line vector layer representing roads, and
+- A point vector layer representing the location of the [Fisher flux tower](https://www.neonscience.org/data-collection/flux-tower-measurements)
   located at the [NEON Harvard Forest field site](https://www.neonscience.org/field-sites/field-sites-map/HARV).
 
-The first shapefile that we will open contains the boundary of our study area
+The first vector layer that we will open contains the boundary of our study area
 (or our Area Of Interest or AOI, hence the name `aoiBoundary`). To import
-shapefiles we use the `sf` function `st_read()`. `st_read()` requires the file 
-path to the shapefile.
+a vector layer from an ESRI `shapefile` we use the `sf` function `st_read()`. `st_read()`
+requires the file path to the ESRI `shapefile`.
 
 Let's import our AOI:
 
@@ -80,20 +80,20 @@ aoi_boundary_HARV <- st_read(
   "data/NEON-DS-Site-Layout-Files/HARV/HarClip_UTMZ18.shp")
 ```
 
-## Shapefile Metadata \& Attributes
+## Vector Layer Metadata \& Attributes
 
-When we import the `HarClip_UTMZ18` shapefile layer into R (as our
+When we import the `HarClip_UTMZ18` vector layer from an ESRI `shapefile` into R (as our
 `aoi_boundary_HARV` object), the `st_read()` function automatically stores
 information about the data. We are particularly interested in the geospatial
-metadata, describing the format, CRS, extent, and other components of the 
-vector data, and the attributes which describe properties associated with each 
+metadata, describing the format, CRS, extent, and other components of the
+vector data, and the attributes which describe properties associated with each
 individual vector object.
 
 :::::::::::::::::::::::::::::::::::::::::  callout
 
 ## Data Tip
 
-The [Explore and Plot by Shapefile Attributes](07-vector-shapefile-attributes-in-r/)
+The [Explore and Plot by Vector Layer Attributes](07-vector-shapefile-attributes-in-r/)
 episode provides more information on both metadata and attributes
 and using attributes to subset and plot data.
 
@@ -102,46 +102,46 @@ and using attributes to subset and plot data.
 
 ## Spatial Metadata
 
-Key metadata for all shapefiles include:
+Key metadata for all vector layers includes:
 
 1. **Object Type:** the class of the imported object.
 2. **Coordinate Reference System (CRS):** the projection of the data.
-3. **Extent:** the spatial extent (i.e. geographic area that the shapefile 
-   covers) of the shapefile. Note that the spatial extent for a shapefile 
-   represents the combined extent for all spatial objects in the shapefile.
+3. **Extent:** the spatial extent (i.e. geographic area that the vector layer
+   covers) of the data. Note that the spatial extent for a vector layer
+   represents the combined extent for all individual objects in the vector layer.
 
-We can view shapefile metadata using the `st_geometry_type()`, `st_crs()` and 
-`st_bbox()` functions. First, let's view the geometry type for our AOI 
-shapefile:
+We can view metadata of a vector layer using the `st_geometry_type()`, `st_crs()` and
+`st_bbox()` functions. First, let's view the geometry type for our AOI
+vector layer:
 
 ```{r}
 st_geometry_type(aoi_boundary_HARV)
 ```
 
-Our `aoi_boundary_HARV` is a polygon object. The 18 levels shown below our 
-output list the possible categories of the geometry type. Now let's check what 
+Our `aoi_boundary_HARV` is a polygon spatial object. The 18 levels shown below our
+output list the possible categories of the geometry type. Now let's check what
 CRS this file data is in:
 
 ```{r}
 st_crs(aoi_boundary_HARV)
 ```
 
-Our data in the CRS **UTM zone 18N**. The CRS is critical to interpreting the 
-object's extent values as it specifies units. To find the extent of our AOI, we 
+Our data in the CRS **UTM zone 18N**. The CRS is critical to interpreting the
+spatial object's extent values as it specifies units. To find the extent of our AOI, we
 can use the `st_bbox()` function:
 
 ```{r}
 st_bbox(aoi_boundary_HARV)
 ```
 
-The spatial extent of a shapefile or R spatial object represents the geographic 
-"edge" or location that is the furthest north, south east and west. Thus is 
-represents the overall geographic coverage of the spatial object. Image Source: 
+The spatial extent of a vector layer or R spatial object represents the geographic
+"edge" or location that is the furthest north, south east and west. Thus it
+represents the overall geographic coverage of the spatial object. Image Source:
 National Ecological Observatory Network (NEON).
 
 ![](fig/dc-spatial-vector/spatial_extent.png){alt='Extent image'}
 
-Lastly, we can view all of the metadata and attributes for this shapefile 
+Lastly, we can view all of the metadata and attributes for this R spatial
 object by printing it to the screen:
 
 ```{r}
@@ -150,33 +150,33 @@ aoi_boundary_HARV
 
 ## Spatial Data Attributes
 
-We introduced the idea of spatial data attributes in 
-[an earlier lesson](https://datacarpentry.org/organization-geospatial/02-intro-vector-data). 
-Now we will explore how to use spatial data attributes stored in our data to 
+We introduced the idea of spatial data attributes in
+[an earlier lesson](https://datacarpentry.org/organization-geospatial/02-intro-vector-data).
+Now we will explore how to use spatial data attributes stored in our data to
 plot different features.
 
-## Plot a Shapefile
+## Plot a vector layer
 
-Next, let's visualize the data in our `sf` object using the `ggplot` package. 
-Unlike with raster data, we do not need to convert vector data to a dataframe 
+Next, let's visualize the data in our `sf` object using the `ggplot` package.
+Unlike with raster data, we do not need to convert vector data to a dataframe
 before plotting with `ggplot`.
 
-We're going to customize our boundary plot by setting the size, color, and fill 
-for our plot. When plotting `sf` objects with `ggplot2`, you need to use the 
+We're going to customize our boundary plot by setting the size, color, and fill
+for our plot. When plotting `sf` objects with `ggplot2`, you need to use the
 `coord_sf()` coordinate system.
 
 ```{r plot-shapefile}
-ggplot() + 
-  geom_sf(data = aoi_boundary_HARV, size = 3, color = "black", fill = "cyan1") + 
-  ggtitle("AOI Boundary Plot") + 
+ggplot() +
+  geom_sf(data = aoi_boundary_HARV, size = 3, color = "black", fill = "cyan1") +
+  ggtitle("AOI Boundary Plot") +
   coord_sf()
 ```
 
 :::::::::::::::::::::::::::::::::::::::  challenge
 
-## Challenge: Import Line and Point Shapefiles
+## Challenge: Import Line and Point Vector Layers
 
-Using the steps above, import the HARV\_roads and HARVtower\_UTM18N layers into
+Using the steps above, import the HARV\_roads and HARVtower\_UTM18N vector layers into
 R. Call the HARV\_roads object `lines_HARV` and the HARVtower\_UTM18N
 `point_HARV`.
 
@@ -217,8 +217,8 @@ st_crs(point_HARV)
 st_bbox(point_HARV)
 ```
 
-To see the number of objects in each file, we can look at the output from when 
-we read these objects into R. `lines_HARV` contains 13 features (all lines) and 
+To see the number of objects in each file, we can look at the output from when
+we read these objects into R. `lines_HARV` contains 13 features (all lines) and
 `point_HARV` contains only one point.
 
 
@@ -231,9 +231,9 @@ we read these objects into R. `lines_HARV` contains 13 features (all lines) and
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
-- Shapefile metadata include geometry type, CRS, and extent.
+- Metadata for vector layers include geometry type, CRS, and extent.
 - Load spatial objects into R with the `st_read()` function.
-- Spatial objects can be plotted directly with `ggplot` using the `geom_sf()` 
+- Spatial objects can be plotted directly with `ggplot` using the `geom_sf()`
   function. No need to convert to a dataframe.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/07-vector-shapefile-attributes-in-r.Rmd
+++ b/episodes/07-vector-shapefile-attributes-in-r.Rmd
@@ -42,30 +42,30 @@ aoi_boundary_HARV <- st_read(
 
 ## Things You'll Need To Complete This Episode
 
-See the [lesson homepage](.) for detailed information about the software, data, 
-and other prerequisites you will need to work through the examples in this 
+See the [lesson homepage](.) for detailed information about the software, data,
+and other prerequisites you will need to work through the examples in this
 episode.
 
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-This episode continues our discussion of vector layer attributes and covers how 
-to work with vector layer attributes in R. It covers how to identify and query 
-layer attributes, as well as how to subset features by specific attribute 
-values. Finally, we will learn how to plot a feature according to a set of 
+This episode continues our discussion of vector layer attributes and covers how
+to work with vector layer attributes in R. It covers how to identify and query
+layer attributes, as well as how to subset features by specific attribute
+values. Finally, we will learn how to plot a feature according to a set of
 attribute values.
 
 ## Load the Data
 
-We will continue using the `sf`, `terra` and `ggplot2` packages in this 
-episode. Make sure that you have these packages loaded. We will continue to 
-work with the three shapefiles (vector layers) that we loaded in the
-[Open and Plot Shapefiles in R](06-vector-open-shapefile-in-r/) episode.
+We will continue using the `sf`, `terra` and `ggplot2` packages in this
+episode. Make sure that you have these packages loaded. We will continue to
+work with the three ESRI `shapefiles` (vector layers) that we loaded in the
+[Open and Plot Vector Layers in R](06-vector-open-shapefile-in-r/) episode.
 
 ## Query Vector Feature Metadata
 
 As we discussed in the
-[Open and Plot Shapefiles in R](06-vector-open-shapefile-in-r/) 
+[Open and Plot Vector Layers in R](06-vector-open-shapefile-in-r/)
 episode, we can view metadata associated with an R object using:
 
 - `st_geometry_type()` - The type of vector data stored in the object.
@@ -74,31 +74,31 @@ episode, we can view metadata associated with an R object using:
   of the object.
 - `st_crs()` - The CRS (spatial projection) of the data.
 
-We started to explore our `point_HARV` object in the previous episode. To see a 
-summary of all of the metadata associated with our `point_HARV` object, we can 
-view the object with `View(point_HARV)` or print a summary of the object itself 
+We started to explore our `point_HARV` object in the previous episode. To see a
+summary of all of the metadata associated with our `point_HARV` object, we can
+view the object with `View(point_HARV)` or print a summary of the object itself
 to the console.
 
 ```{r view-object}
 point_HARV
 ```
 
-We can use the `ncol` function to count the number of attributes associated 
-with a spatial object too. Note that the geometry is just another column and 
+We can use the `ncol` function to count the number of attributes associated
+with a spatial object too. Note that the geometry is just another column and
 counts towards the total.
 
 ```{r shapefile-attributes}
 ncol(lines_HARV)
 ```
 
-We can view the individual name of each attribute using the `names()` function 
+We can view the individual name of each attribute using the `names()` function
 in R:
 
 ```{r view-shapefile-attributes}
 names(lines_HARV)
 ```
 
-We could also view just the first 6 rows of attribute values using the `head()` 
+We could also view just the first 6 rows of attribute values using the `head()`
 function to get a preview of the data:
 
 ```{r view-shapefile-attributes-head}
@@ -109,7 +109,7 @@ head(lines_HARV)
 
 ## Challenge: Attributes for Different Spatial Classes
 
-Explore the attributes associated with the `point_HARV` and `aoi_boundary_HARV` 
+Explore the attributes associated with the `point_HARV` and `aoi_boundary_HARV`
 spatial objects.
 
 1. How many attributes does each have?
@@ -117,7 +117,7 @@ spatial objects.
 2. Who owns the site in the `point_HARV` data object?
 
 3. Which of the following is NOT an attribute of the `point_HARV` data object?
-  
+
   A) Latitude      B) County     C) Country
 
 :::::::::::::::  solution
@@ -154,9 +154,9 @@ names(point_HARV)
 ## Explore Values within One Attribute
 
 We can explore individual values stored within a particular attribute.
-Comparing attributes to a spreadsheet or a data frame, this is similar to 
-exploring values in a column. We did this with the `gapminder` dataframe in 
-[an earlier lesson](https://datacarpentry.org/r-intro-geospatial/05-data-subsetting/index.html). 
+Comparing attributes to a spreadsheet or a data frame, this is similar to
+exploring values in a column. We did this with the `gapminder` dataframe in
+[an earlier lesson](https://datacarpentry.org/r-intro-geospatial/05-data-subsetting/index.html).
 For spatial objects, we can use the same syntax: `objectName$attributeName`.
 
 We can see the contents of the `TYPE` field of our lines feature:
@@ -165,10 +165,10 @@ We can see the contents of the `TYPE` field of our lines feature:
 lines_HARV$TYPE
 ```
 
-To see only unique values within the `TYPE` field, we can use the `unique()` 
-function for extracting the possible values of a character variable (R also is 
-able to handle categorical variables called factors; we worked with factors a 
-little bit in 
+To see only unique values within the `TYPE` field, we can use the `unique()`
+function for extracting the possible values of a character variable (R also is
+able to handle categorical variables called factors; we worked with factors a
+little bit in
 [an earlier lesson](https://datacarpentry.org/r-intro-geospatial/03-data-structures-part1/index.html).
 
 ```{r explor-attribute-values-factor}
@@ -177,29 +177,29 @@ unique(lines_HARV$TYPE)
 
 ### Subset Features
 
-We can use the `filter()` function from `dplyr` that we worked with in 
-[an earlier lesson](https://datacarpentry.org/r-intro-geospatial/06-dplyr) 
-to select a subset of features from a spatial object in R, just like with data 
+We can use the `filter()` function from `dplyr` that we worked with in
+[an earlier lesson](https://datacarpentry.org/r-intro-geospatial/06-dplyr)
+to select a subset of features from a spatial object in R, just like with data
 frames.
 
-For example, we might be interested only in features that are of `TYPE` 
-"footpath". Once we subset out this data, we can use it as input to other code 
+For example, we might be interested only in features that are of `TYPE`
+"footpath". Once we subset out this data, we can use it as input to other code
 so that code only operates on the footpath lines.
 
 ```{r Subsetting-shapefiles}
-footpath_HARV <- lines_HARV %>% 
+footpath_HARV <- lines_HARV %>%
   filter(TYPE == "footpath")
 nrow(footpath_HARV)
 ```
 
-Our subsetting operation reduces the `features` count to 2. This means that 
+Our subsetting operation reduces the `features` count to 2. This means that
 only two feature lines in our spatial object have the attribute
 `TYPE == footpath`. We can plot only the footpath lines:
 
 ```{r plot-subset-shapefile, fig.cap="Map of the footpaths in the study area."}
-ggplot() + 
+ggplot() +
   geom_sf(data = footpath_HARV) +
-  ggtitle("NEON Harvard Forest Field Site", subtitle = "Footpaths") + 
+  ggtitle("NEON Harvard Forest Field Site", subtitle = "Footpaths") +
   coord_sf()
 ```
 
@@ -213,10 +213,10 @@ Note that size is placed outside of the `aes()` function, as we are not
 connecting line thickness to a data variable.
 
 ```{r plot-subset-shapefile-unique-colors, fig.cap="Map of the footpaths in the study area where each feature is colored differently."}
-ggplot() + 
+ggplot() +
   geom_sf(data = footpath_HARV, aes(color = factor(OBJECTID)), size = 1.5) +
   labs(color = 'Footpath ID') +
-  ggtitle("NEON Harvard Forest Field Site", subtitle = "Footpaths") + 
+  ggtitle("NEON Harvard Forest Field Site", subtitle = "Footpaths") +
   coord_sf()
 ```
 
@@ -235,7 +235,7 @@ Subset out all `boardwalk` from the lines layer and plot it.
 First we will save an object with only the boardwalk lines:
 
 ```{r}
-boardwalk_HARV <- lines_HARV %>% 
+boardwalk_HARV <- lines_HARV %>%
   filter(TYPE == "boardwalk")
 ```
 
@@ -248,9 +248,9 @@ nrow(boardwalk_HARV)
 Now let's plot that data:
 
 ```{r harv-boardwalk-map, fig.cap="Map of the boardwalks in the study area."}
-ggplot() + 
+ggplot() +
   geom_sf(data = boardwalk_HARV, size = 1.5) +
-  ggtitle("NEON Harvard Forest Field Site", subtitle = "Boardwalks") + 
+  ggtitle("NEON Harvard Forest Field Site", subtitle = "Boardwalks") +
   coord_sf()
 ```
 
@@ -262,18 +262,18 @@ ggplot() +
 
 ## Challenge: Subset Spatial Line Objects Part 2
 
-Subset out all `stone wall` features from the lines layer and plot it. For each 
+Subset out all `stone wall` features from the lines layer and plot it. For each
 plot, color each feature using a unique color.
 
 :::::::::::::::  solution
 
 ## Answer
 
-First we will save an object with only the stone wall lines and check the 
+First we will save an object with only the stone wall lines and check the
 number of features:
 
 ```{r}
-stoneWall_HARV <- lines_HARV %>% 
+stoneWall_HARV <- lines_HARV %>%
   filter(TYPE == "stone wall")
 nrow(stoneWall_HARV)
 ```
@@ -284,7 +284,7 @@ Now we can plot the data:
 ggplot() +
   geom_sf(data = stoneWall_HARV, aes(color = factor(OBJECTID)), size = 1.5) +
   labs(color = 'Wall ID') +
-  ggtitle("NEON Harvard Forest Field Site", subtitle = "Stonewalls") + 
+  ggtitle("NEON Harvard Forest Field Site", subtitle = "Stonewalls") +
   coord_sf()
 ```
 
@@ -294,9 +294,9 @@ ggplot() +
 
 ## Customize Plots
 
-In the examples above, `ggplot()` automatically selected colors for each line 
-based on a default color order. If we don't like those default colors, we can 
-create a vector of colors - one for each feature. 
+In the examples above, `ggplot()` automatically selected colors for each line
+based on a default color order. If we don't like those default colors, we can
+create a vector of colors - one for each feature.
 
 First we will check how many unique levels our factor has:
 
@@ -315,21 +315,21 @@ We can tell `ggplot` to use these colors when we plot the data.
 
 ```{r harv-paths-map, fig.cap="Roads and trails in the area."}
 ggplot() +
-  geom_sf(data = lines_HARV, aes(color = TYPE)) + 
+  geom_sf(data = lines_HARV, aes(color = TYPE)) +
   scale_color_manual(values = road_colors) +
   labs(color = 'Road Type') +
-  ggtitle("NEON Harvard Forest Field Site", subtitle = "Roads & Trails") + 
+  ggtitle("NEON Harvard Forest Field Site", subtitle = "Roads & Trails") +
   coord_sf()
 ```
 
 
 ### Adjust Line Width
 
-We adjusted line width universally earlier. If we want a unique line width for 
-each level or attribute category in our spatial object, we can use the 
+We adjusted line width universally earlier. If we want a unique line width for
+each level or attribute category in our spatial object, we can use the
 same syntax that we used for colors, above.
 
-We already know that we have four different `TYPE`s in the lines\_HARV object, 
+We already know that we have four different `TYPE`s in the lines\_HARV object,
 so we will set four different line widths.
 
 ```{r line-width-unique}
@@ -340,12 +340,12 @@ We can use those line widths when we plot the data.
 
 ```{r harv-paths-map-wide, fig.cap="Roads and trails in the area demonstrating how to use different line thickness and colors."}
 ggplot() +
-  geom_sf(data = lines_HARV, aes(color = TYPE, size = TYPE)) + 
+  geom_sf(data = lines_HARV, aes(color = TYPE, size = TYPE)) +
   scale_color_manual(values = road_colors) +
   labs(color = 'Road Type') +
   scale_size_manual(values = line_widths) +
-  ggtitle("NEON Harvard Forest Field Site", 
-          subtitle = "Roads & Trails - Line width varies") + 
+  ggtitle("NEON Harvard Forest Field Site",
+          subtitle = "Roads & Trails - Line width varies") +
   coord_sf()
 ```
 
@@ -354,11 +354,11 @@ ggplot() +
 
 ## Challenge: Plot Line Width by Attribute
 
-In the example above, we set the line widths to be 1, 2, 3, and 4. Because R 
-orders alphabetically by default, this gave us a plot where woods roads (the 
+In the example above, we set the line widths to be 1, 2, 3, and 4. Because R
+orders alphabetically by default, this gave us a plot where woods roads (the
 last type) were the thickest and boardwalks were the thinnest.
 
-Let's create another plot where we show the different line types with the 
+Let's create another plot where we show the different line types with the
 following thicknesses:
 
 1. woods road size = 6
@@ -390,8 +390,8 @@ Now we can create our plot.
 ggplot() +
   geom_sf(data = lines_HARV, aes(size = TYPE)) +
   scale_size_manual(values = line_width) +
-  ggtitle("NEON Harvard Forest Field Site", 
-          subtitle = "Roads & Trails - Line width varies") + 
+  ggtitle("NEON Harvard Forest Field Site",
+          subtitle = "Roads & Trails - Line width varies") +
   coord_sf()
 ```
 
@@ -407,9 +407,9 @@ elements to specify labels and colors:
 - `bottomright`: We specify the location of our legend by using a default
   keyword. We could also use `top`, `topright`, etc.
 - `levels(objectName$attributeName)`: Label the legend elements using the
-  categories of levels in an attribute (e.g., levels(lines\_HARV$TYPE) means 
+  categories of levels in an attribute (e.g., levels(lines\_HARV$TYPE) means
   use the levels boardwalk, footpath, etc).
-- `fill =`: apply unique colors to the boxes in our legend. `palette()` is the 
+- `fill =`: apply unique colors to the boxes in our legend. `palette()` is the
   default set of colors that R applies to all plots.
 
 Let's add a legend to our plot. We will use the `road_colors` object
@@ -417,29 +417,29 @@ that we created above to color the legend. We can customize the
 appearance of our legend by manually setting different parameters.
 
 ```{r add-legend-to-plot, fig.cap="Roads and trails in the study area using thicker lines than the previous figure."}
-ggplot() + 
+ggplot() +
   geom_sf(data = lines_HARV, aes(color = TYPE), size = 1.5) +
   scale_color_manual(values = road_colors) +
-  labs(color = 'Road Type') + 
-  ggtitle("NEON Harvard Forest Field Site", 
-          subtitle = "Roads & Trails - Default Legend") + 
+  labs(color = 'Road Type') +
+  ggtitle("NEON Harvard Forest Field Site",
+          subtitle = "Roads & Trails - Default Legend") +
   coord_sf()
 ```
 
-We can change the appearance of our legend by manually setting different 
+We can change the appearance of our legend by manually setting different
 parameters.
 
 - `legend.text`: change the font size
 - `legend.box.background`: add an outline box
 
 ```{r modify-legend-plot, fig.cap="Map of the paths in the study area with large-font and border around the legend."}
-ggplot() + 
+ggplot() +
   geom_sf(data = lines_HARV, aes(color = TYPE), size = 1.5) +
-  scale_color_manual(values = road_colors) + 
+  scale_color_manual(values = road_colors) +
   labs(color = 'Road Type') +
-  theme(legend.text = element_text(size = 20), 
-        legend.box.background = element_rect(size = 1)) + 
-  ggtitle("NEON Harvard Forest Field Site", 
+  theme(legend.text = element_text(size = 20),
+        legend.box.background = element_rect(size = 1)) +
+  ggtitle("NEON Harvard Forest Field Site",
           subtitle = "Roads & Trails - Modified Legend") +
   coord_sf()
 ```
@@ -447,13 +447,13 @@ ggplot() +
 ```{r plot-different-colors, fig.cap="Map of the paths in the study area using a different color palette."}
 new_colors <- c("springgreen", "blue", "magenta", "orange")
 
-ggplot() + 
-  geom_sf(data = lines_HARV, aes(color = TYPE), size = 1.5) + 
+ggplot() +
+  geom_sf(data = lines_HARV, aes(color = TYPE), size = 1.5) +
   scale_color_manual(values = new_colors) +
   labs(color = 'Road Type') +
-  theme(legend.text = element_text(size = 20), 
-        legend.box.background = element_rect(size = 1)) + 
-  ggtitle("NEON Harvard Forest Field Site", 
+  theme(legend.text = element_text(size = 20),
+        legend.box.background = element_rect(size = 1)) +
+  ggtitle("NEON Harvard Forest Field Site",
           subtitle = "Roads & Trails - Pretty Colors") +
   coord_sf()
 ```
@@ -462,12 +462,12 @@ ggplot() +
 
 ## Data Tip
 
-You can modify the default R color palette using the palette method. For 
-example `palette(rainbow(6))` or `palette(terrain.colors(6))`. You can reset 
+You can modify the default R color palette using the palette method. For
+example `palette(rainbow(6))` or `palette(terrain.colors(6))`. You can reset
 the palette colors using `palette("default")`!
 
-You can also use colorblind-friendly palettes such as those in the 
-[viridis package](https://cran.r-project.org/package=viridis). 
+You can also use colorblind-friendly palettes such as those in the
+[viridis package](https://cran.r-project.org/package=viridis).
 
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -490,7 +490,7 @@ other lines can be black.
 
 ## Answers
 
-First we need to make sure that the `BicyclesHo` attribute is a factor and 
+First we need to make sure that the `BicyclesHo` attribute is a factor and
 check how many levels it has.
 
 ```{r}
@@ -502,27 +502,27 @@ levels(lines_HARV$BicyclesHo)
 Next, we will create a new object `lines_removeNA` that removes missing values.
 
 ```{r}
-lines_removeNA <- lines_HARV[!is.na(lines_HARV$BicyclesHo),] 
+lines_removeNA <- lines_HARV[!is.na(lines_HARV$BicyclesHo),]
 ```
 
-In our plot, we will set colors so that only the allowed roads are magenta, and 
-we will set line width so that the first factor level is thicker than the 
+In our plot, we will set colors so that only the allowed roads are magenta, and
+we will set line width so that the first factor level is thicker than the
 others.
 
 ```{r harv-paths-bike-horses, fig.cap="Roads and trails in the area highlighting paths where horses and bikes are allowed."}
-# First, create a data frame with only those roads where bicycles and horses 
+# First, create a data frame with only those roads where bicycles and horses
 # are allowed
-lines_showHarv <- 
-  lines_removeNA %>% 
+lines_showHarv <-
+  lines_removeNA %>%
   filter(BicyclesHo == "Bicycles and Horses Allowed")
 
 # Next, visualise using ggplot
-ggplot() + 
-  geom_sf(data = lines_HARV) + 
-  geom_sf(data = lines_showHarv, aes(color = BicyclesHo), size = 2) + 
+ggplot() +
+  geom_sf(data = lines_HARV) +
+  geom_sf(data = lines_showHarv, aes(color = BicyclesHo), size = 2) +
   scale_color_manual(values = "magenta") +
-  ggtitle("NEON Harvard Forest Field Site", 
-          subtitle = "Roads Where Bikes and Horses Are Allowed") + 
+  ggtitle("NEON Harvard Forest Field Site",
+          subtitle = "Roads Where Bikes and Horses Are Allowed") +
   coord_sf()
 ```
 
@@ -542,11 +542,11 @@ ggplot() +
 
 ## Answers
 
-First we read in the data and check how many levels there are in the `region` 
+First we read in the data and check how many levels there are in the `region`
 column:
 
 ```{r}
-state_boundary_US <- 
+state_boundary_US <-
 st_read("data/NEON-DS-Site-Layout-Files/US-Boundary-Layers/US-State-Boundaries-Census-2014.shp") %>%
 # NOTE: We need neither Z nor M coordinates!
 st_zm()
@@ -567,7 +567,7 @@ Now we can create our plot:
 ggplot() +
   geom_sf(data = state_boundary_US, aes(color = region), size = 1) +
   scale_color_manual(values = colors) +
-  ggtitle("Contiguous U.S. State Boundaries") + 
+  ggtitle("Contiguous U.S. State Boundaries") +
   coord_sf()
 ```
 
@@ -579,9 +579,9 @@ ggplot() +
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
-- Spatial objects in `sf` are similar to standard data frames and can be 
+- Spatial objects in `sf` are similar to standard data frames and can be
   manipulated using the same functions.
-- Almost any feature of a plot can be customized using the various functions 
+- Almost any feature of a plot can be customized using the various functions
   and options in the `ggplot2` package.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/08-vector-plot-shapefiles-custom-legend.Rmd
+++ b/episodes/08-vector-plot-shapefiles-custom-legend.Rmd
@@ -1,5 +1,5 @@
 ---
-title: Plot Multiple Shapefiles
+title: Plot Multiple Vector Layers
 teaching: 40
 exercises: 20
 source: Rmd
@@ -11,7 +11,7 @@ source("setup.R")
 
 ::::::::::::::::::::::::::::::::::::::: objectives
 
-- Plot multiple shapefiles in the same plot.
+- Plot multiple vector layers in the same plot.
 - Apply custom symbols to spatial objects in a plot.
 - Create a multi-layered plot with raster and vector data.
 
@@ -45,8 +45,8 @@ road_colors <- c("blue", "green", "navy", "purple")
 
 ## Things You'll Need To Complete This Episode
 
-See the [lesson homepage](.) for detailed information about the software, data, 
-and other prerequisites you will need to work through the examples in this 
+See the [lesson homepage](.) for detailed information about the software, data,
+and other prerequisites you will need to work through the examples in this
 episode.
 
 
@@ -54,8 +54,8 @@ episode.
 
 This episode builds upon
 [the previous episode](07-vector-shapefile-attributes-in-r/)
-to work with shapefile attributes in R and explores how to plot multiple
-shapefiles. It also covers how to plot raster and vector data together on the 
+to work with vector layers in R and explore how to plot multiple
+vector layers. It also covers how to plot raster and vector data together on the
 same plot.
 
 ## Load the Data
@@ -64,69 +64,69 @@ To work with vector data in R, we can use the `sf` library. The `terra`
 package also allows us to explore metadata using similar commands for both
 raster and vector files. Make sure that you have these packages loaded.
 
-We will continue to work with the three shapefiles that we loaded in the
-[Open and Plot Shapefiles in R](06-vector-open-shapefile-in-r/) episode.
+We will continue to work with the three ESRI `shapefile` that we loaded in the
+[Open and Plot Vector Layers in R](06-vector-open-shapefile-in-r/) episode.
 
-## Plotting Multiple Shapefiles
+## Plotting Multiple Vector Layers
 
-In the [previous episode](07-vector-shapefile-attributes-in-r/), we learned how 
-to plot information from a single shapefile and do some plot customization 
-including adding a custom legend. However, what if we want to create a more 
-complex plot with many shapefiles and unique symbols that need to be 
+In the [previous episode](07-vector-shapefile-attributes-in-r/), we learned how
+to plot information from a single vector layer and do some plot customization
+including adding a custom legend. However, what if we want to create a more
+complex plot with many vector layers and unique symbols that need to be
 represented clearly in a legend?
 
-Now, let's create a plot that combines our tower location (`point_HARV`), site 
-boundary (`aoi_boundary_HARV`) and roads (`lines_HARV`) spatial objects. We 
+Now, let's create a plot that combines our tower location (`point_HARV`), site
+boundary (`aoi_boundary_HARV`) and roads (`lines_HARV`) spatial objects. We
 will need to build a custom legend as well.
 
-To begin, we will create a plot with the site boundary as the first layer. Then 
+To begin, we will create a plot with the site boundary as the first layer. Then
 layer the tower location and road data on top using `+`.
 
 ```{r plot-many-shapefiles}
-ggplot() + 
+ggplot() +
   geom_sf(data = aoi_boundary_HARV, fill = "grey", color = "grey") +
   geom_sf(data = lines_HARV, aes(color = TYPE), size = 1) +
   geom_sf(data = point_HARV) +
-  ggtitle("NEON Harvard Forest Field Site") + 
+  ggtitle("NEON Harvard Forest Field Site") +
   coord_sf()
 ```
 
-Next, let's build a custom legend using the symbology (the colors and symbols) 
-that we used to create the plot above. For example, it might be good if the 
-lines were symbolized as lines. In the previous episode, you may have noticed 
-that the default legend behavior for `geom_sf` is to draw a 'patch' for each 
-legend entry. If you want the legend to draw lines or points, you need to add 
+Next, let's build a custom legend using the symbology (the colors and symbols)
+that we used to create the plot above. For example, it might be good if the
+lines were symbolized as lines. In the previous episode, you may have noticed
+that the default legend behavior for `geom_sf` is to draw a 'patch' for each
+legend entry. If you want the legend to draw lines or points, you need to add
 an instruction to the `geom_sf` call - in this case, `show.legend = 'line'`.
 
 ```{r plot-custom-shape}
-ggplot() + 
+ggplot() +
   geom_sf(data = aoi_boundary_HARV, fill = "grey", color = "grey") +
   geom_sf(data = lines_HARV, aes(color = TYPE),
           show.legend = "line", size = 1) +
   geom_sf(data = point_HARV, aes(fill = Sub_Type), color = "black") +
   scale_color_manual(values = road_colors) +
   scale_fill_manual(values = "black") +
-  ggtitle("NEON Harvard Forest Field Site") + 
+  ggtitle("NEON Harvard Forest Field Site") +
   coord_sf()
 ```
 
-Now lets adjust the legend titles by passing a `name` to the respective `color` 
+Now lets adjust the legend titles by passing a `name` to the respective `color`
 and `fill` palettes.
 
 ```{r create-custom-legend}
-ggplot() + 
+ggplot() +
   geom_sf(data = aoi_boundary_HARV, fill = "grey", color = "grey") +
   geom_sf(data = point_HARV, aes(fill = Sub_Type)) +
   geom_sf(data = lines_HARV, aes(color = TYPE), show.legend = "line",
-          size = 1) + 
-  scale_color_manual(values = road_colors, name = "Line Type") + 
-  scale_fill_manual(values = "black", name = "Tower Location") + 
-  ggtitle("NEON Harvard Forest Field Site") + 
+          size = 1) +
+  scale_color_manual(values = road_colors, name = "Line Type") +
+  scale_fill_manual(values = "black", name = "Tower Location") +
+  ggtitle("NEON Harvard Forest Field Site") +
   coord_sf()
 ```
 
-Finally, it might be better if the points were symbolized as a symbol. We can 
-customize this using `shape` parameters in our call to `geom_sf`: 16 is a point 
+Finally, it might be better if the points were symbolized as a symbol. We can
+customize this using `shape` parameters in our call to `geom_sf`: 16 is a point
 symbol, 15 is a box.
 
 :::::::::::::::::::::::::::::::::::::::::  callout
@@ -147,7 +147,7 @@ ggplot() +
           show.legend = "line", size = 1) +
   scale_color_manual(values = road_colors, name = "Line Type") +
   scale_fill_manual(values = "black", name = "Tower Location") +
-  ggtitle("NEON Harvard Forest Field Site") + 
+  ggtitle("NEON Harvard Forest Field Site") +
   coord_sf()
 ```
 
@@ -155,25 +155,25 @@ ggplot() +
 
 ## Challenge: Plot Polygon by Attribute
 
-1. Using the `NEON-DS-Site-Layout-Files/HARV/PlotLocations_HARV.shp` shapefile,
-  create a map of study plot locations, with each point colored by the soil 
-  type (`soilTypeOr`). How many different soil types are there at this 
-  particular field site? Overlay this layer on top of the `lines_HARV` layer 
-  (the roads). Create a custom legend that applies line symbols to lines and 
+1. Using the `NEON-DS-Site-Layout-Files/HARV/PlotLocations_HARV.shp` ESRI `shapefile`,
+  create a map of study plot locations, with each point colored by the soil
+  type (`soilTypeOr`). How many different soil types are there at this
+  particular field site? Overlay this layer on top of the `lines_HARV` layer
+  (the roads). Create a custom legend that applies line symbols to lines and
   point symbols to the points.
 
-2. Modify the plot above. Tell R to plot each point, using a different symbol 
+2. Modify the plot above. Tell R to plot each point, using a different symbol
    of `shape` value.
 
 :::::::::::::::  solution
 
 ## Answers
 
-First we need to read in the data and see how many unique soils are represented 
+First we need to read in the data and see how many unique soils are represented
 in the `soilTypeOr` attribute.
 
 ```{r}
-plot_locations <- 
+plot_locations <-
   st_read("data/NEON-DS-Site-Layout-Files/HARV/PlotLocations_HARV.shp")
 
 plot_locations$soilTypeOr <- as.factor(plot_locations$soilTypeOr)
@@ -189,35 +189,35 @@ blue_orange <- c("cornflowerblue", "darkorange")
 Finally, we will create our plot.
 
 ```{r harv-plot-locations-bg}
-ggplot() + 
-  geom_sf(data = lines_HARV, aes(color = TYPE), show.legend = "line") + 
-  geom_sf(data = plot_locations, aes(fill = soilTypeOr), 
-          shape = 21, show.legend = 'point') + 
+ggplot() +
+  geom_sf(data = lines_HARV, aes(color = TYPE), show.legend = "line") +
+  geom_sf(data = plot_locations, aes(fill = soilTypeOr),
+          shape = 21, show.legend = 'point') +
   scale_color_manual(name = "Line Type", values = road_colors,
-     guide = guide_legend(override.aes = list(linetype = "solid", 
-                                              shape = NA))) + 
+     guide = guide_legend(override.aes = list(linetype = "solid",
+                                              shape = NA))) +
   scale_fill_manual(name = "Soil Type", values = blue_orange,
-     guide = guide_legend(override.aes = list(linetype = "blank", shape = 21, 
-                                              colour = NA))) + 
-  ggtitle("NEON Harvard Forest Field Site") + 
+     guide = guide_legend(override.aes = list(linetype = "blank", shape = 21,
+                                              colour = NA))) +
+  ggtitle("NEON Harvard Forest Field Site") +
   coord_sf()
 ```
 
-If we want each soil to be shown with a different symbol, we can give multiple 
+If we want each soil to be shown with a different symbol, we can give multiple
 values to the `scale_shape_manual()` argument.
 
 ```{r harv-plot-locations-pch}
-ggplot() + 
-  geom_sf(data = lines_HARV, aes(color = TYPE), show.legend = "line", size = 1) + 
+ggplot() +
+  geom_sf(data = lines_HARV, aes(color = TYPE), show.legend = "line", size = 1) +
   geom_sf(data = plot_locations, aes(fill = soilTypeOr, shape = soilTypeOr),
-          show.legend = 'point', size = 3) + 
+          show.legend = 'point', size = 3) +
   scale_shape_manual(name = "Soil Type", values = c(21, 22)) +
   scale_color_manual(name = "Line Type", values = road_colors,
-     guide = guide_legend(override.aes = list(linetype = "solid", shape = NA))) + 
+     guide = guide_legend(override.aes = list(linetype = "solid", shape = NA))) +
   scale_fill_manual(name = "Soil Type", values = blue_orange,
      guide = guide_legend(override.aes = list(linetype = "blank", shape = c(21, 22),
-     color = blue_orange))) + 
-  ggtitle("NEON Harvard Forest Field Site") + 
+     color = blue_orange))) +
+  ggtitle("NEON Harvard Forest Field Site") +
   coord_sf()
 ```
 
@@ -229,9 +229,9 @@ ggplot() +
 
 ## Challenge: Plot Raster \& Vector Data Together
 
-You can plot vector data layered on top of raster data using the `+` to add a 
-layer in `ggplot`. Create a plot that uses the NEON AOI Canopy Height Model 
-`data/NEON-DS-Airborne-Remote-Sensing/HARV/CHM/HARV_chmCrop.tif` as a base 
+You can plot vector data layered on top of raster data using the `+` to add a
+layer in `ggplot`. Create a plot that uses the NEON AOI Canopy Height Model
+`data/NEON-DS-Airborne-Remote-Sensing/HARV/CHM/HARV_chmCrop.tif` as a base
 layer. On top of the CHM, please add:
 
 - The study site AOI.
@@ -250,7 +250,7 @@ ggplot() +
   geom_sf(data = lines_HARV, color = "black") +
   geom_sf(data = aoi_boundary_HARV, color = "grey20", size = 1) +
   geom_sf(data = point_HARV, pch = 8) +
-  ggtitle("NEON Harvard Forest Field Site w/ Canopy Height Model") + 
+  ggtitle("NEON Harvard Forest Field Site w/ Canopy Height Model") +
   coord_sf()
 ```
 

--- a/episodes/09-vector-when-data-dont-line-up-crs.Rmd
+++ b/episodes/09-vector-when-data-dont-line-up-crs.Rmd
@@ -32,25 +32,25 @@ library(dplyr)
 
 ## Things You'll Need To Complete This Episode
 
-See the [lesson homepage](.) for detailed information about the software, data, 
-and other prerequisites you will need to work through the examples in this 
+See the [lesson homepage](.) for detailed information about the software, data,
+and other prerequisites you will need to work through the examples in this
 episode.
 
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 In [an earlier episode](03-raster-reproject-in-r/)
-we learned how to handle a situation where you have two different files with 
-raster data in different projections. Now we will apply those same principles 
+we learned how to handle a situation where you have two different files with
+raster data in different projections. Now we will apply those same principles
 to working with vector data.
-We will create a base map of our study site using United States state and 
+We will create a base map of our study site using United States state and
 country boundary information accessed from the
 [United States Census Bureau](https://www.census.gov/geo/maps-data/data/cbf/cbf_state.html).
-We will learn how to map vector data that are in different CRSs and thus don't 
+We will learn how to map vector data that are in different CRSs and thus don't
 line up on a map.
 
-We will continue to work with the three shapefiles that we loaded in the
-[Open and Plot Shapefiles in R](06-vector-open-shapefile-in-r/) episode.
+We will continue to work with the three ESRI `shapefiles` that we loaded in the
+[Open and Plot Vector Layers in R](06-vector-open-shapefile-in-r/) episode.
 
 ```{r load-data, echo=FALSE, results="hide", warning=FALSE, message=FALSE}
 # learners will have this data loaded from previous episodes
@@ -64,28 +64,28 @@ roadColors <- c("blue", "green", "grey", "purple")[lines_HARV$TYPE]
 
 ## Working With Spatial Data From Different Sources
 
-We often need to gather spatial datasets from different sources and/or data 
+We often need to gather spatial datasets from different sources and/or data
 that cover different spatial extents.
 These data are often in different Coordinate Reference Systems (CRSs).
 
 Some reasons for data being in different CRSs include:
 
-1. The data are stored in a particular CRS convention used by the data provider 
+1. The data are stored in a particular CRS convention used by the data provider
    (for example, a government agency).
-2. The data are stored in a particular CRS that is customized to a region. For 
-   instance, many states in the US prefer to use a State Plane projection 
+2. The data are stored in a particular CRS that is customized to a region. For
+   instance, many states in the US prefer to use a State Plane projection
    customized for that state.
 
 ![Maps of the United States using data in different projections. Source: opennews.org, from: https://media.opennews.org/cache/06/37/0637aa2541b31f526ad44f7cb2db7b6c.jpg](fig/map_usa_different_projections.jpg){alt='Maps of the United States using data in different projections.}
 
-Notice the differences in shape associated with each different projection. 
-These differences are a direct result of the calculations used to "flatten" the 
-data onto a 2-dimensional map. Often data are stored purposefully in a 
-particular projection that optimizes the relative shape and size of surrounding 
+Notice the differences in shape associated with each different projection.
+These differences are a direct result of the calculations used to "flatten" the
+data onto a 2-dimensional map. Often data are stored purposefully in a
+particular projection that optimizes the relative shape and size of surrounding
 geographic boundaries (states, counties, countries, etc).
 
-In this episode we will learn how to identify and manage spatial data in 
-different projections. We will learn how to reproject the data so that they are 
+In this episode we will learn how to identify and manage spatial data in
+different projections. We will learn how to reproject the data so that they are
 in the same projection to support plotting / mapping. Note that these skills
 are also required for any geoprocessing / spatial analysis. Data need to be in
 the same CRS to ensure accurate results.
@@ -96,10 +96,10 @@ We will continue to use the `sf` and `terra` packages in this episode.
 
 There are many good sources of boundary base layers that we can use to create a
 basemap. Some R packages even have these base layers built in to support quick
-and efficient mapping. In this episode, we will use boundary layers for the 
-contiguous United States, provided by the 
+and efficient mapping. In this episode, we will use boundary layers for the
+contiguous United States, provided by the
 [United States Census Bureau](https://www.census.gov/geo/maps-data/data/cbf/cbf_state.html).
-It is useful to have shapefiles to work with because we can add additional 
+It is useful to have vector layers in ESRI's `shapefile` format to work with because we can add additional
 attributes to them if need be - for project specific mapping.
 
 ## Read US Boundary File
@@ -131,12 +131,12 @@ nicer. We will import
 `NEON-DS-Site-Layout-Files/US-Boundary-Layers/US-Boundary-Dissolved-States`.
 
 ```{r}
-country_boundary_US <- st_read("data/NEON-DS-Site-Layout-Files/US-Boundary-Layers/US-Boundary-Dissolved-States.shp") %>% 
+country_boundary_US <- st_read("data/NEON-DS-Site-Layout-Files/US-Boundary-Layers/US-Boundary-Dissolved-States.shp") %>%
   st_zm()
 ```
 
-If we specify a thicker line width using `size = 2` for the border layer, it 
-will make our map pop! We will also manually set the colors of the state 
+If we specify a thicker line width using `size = 2` for the border layer, it
+will make our map pop! We will also manually set the colors of the state
 boundaries and country boundaries.
 
 ```{r us-boundaries-thickness}
@@ -189,15 +189,15 @@ the lat/long projection as follows:
   is WGS84
 
 Note that there are no specified units above. This is because this geographic
-coordinate reference system is in latitude and longitude which is most often 
+coordinate reference system is in latitude and longitude which is most often
 recorded in decimal degrees.
 
 :::::::::::::::::::::::::::::::::::::::::  callout
 
 ## Data Tip
 
-the last portion of each `proj4` string could potentially be something like 
-`+towgs84=0,0,0 `. This is a conversion factor that is used if a datum 
+the last portion of each `proj4` string could potentially be something like
+`+towgs84=0,0,0 `. This is a conversion factor that is used if a datum
 conversion is required. We will not deal with datums in this episode series.
 
 
@@ -232,21 +232,21 @@ represented in meters.
 - [Official PROJ library documentation](https://proj4.org/)
 - [More information on the proj4 format.](https://proj.maptools.org/faq.html)
 - [A fairly comprehensive list of CRSs by format.](https://spatialreference.org)
-- To view a list of datum conversion factors type: 
+- To view a list of datum conversion factors type:
   `sf_proj_info(type = "datum")` into the R console. However, the results would
   depend on the underlying version of the PROJ library.
-  
+
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 ## Reproject Vector Data or No?
 
-We saw in [an earlier episode](03-raster-reproject-in-r/) that when working 
-with raster data in different CRSs, we needed to convert all objects to the 
-same CRS. We can do the same thing with our vector data - however, we don't 
-need to! When using the `ggplot2` package, `ggplot` automatically converts all 
+We saw in [an earlier episode](03-raster-reproject-in-r/) that when working
+with raster data in different CRSs, we needed to convert all objects to the
+same CRS. We can do the same thing with our vector data - however, we don't
+need to! When using the `ggplot2` package, `ggplot` automatically converts all
 objects to the same CRS before plotting.
-This means we can plot our three data sets together without doing any 
+This means we can plot our three data sets together without doing any
 conversion:
 
 ```{r layer-point-on-states}
@@ -264,12 +264,12 @@ ggplot() +
 
 Create a map of the North Eastern United States as follows:
 
-1. Import and plot `Boundary-US-State-NEast.shp`. Adjust line width as 
+1. Import and plot `Boundary-US-State-NEast.shp`. Adjust line width as
    necessary.
-2. Layer the Fisher Tower (in the NEON Harvard Forest site) point location 
+2. Layer the Fisher Tower (in the NEON Harvard Forest site) point location
    `point_HARV` onto the plot.
 3. Add a title.
-4. Add a legend that shows both the state boundary (as a line) and the Tower 
+4. Add a legend that shows both the state boundary (as a line) and the Tower
    location point.
 
 :::::::::::::::  solution
@@ -281,12 +281,12 @@ NE.States.Boundary.US <- st_read("data/NEON-DS-Site-Layout-Files/US-Boundary-Lay
   st_zm()
 
 ggplot() +
-    geom_sf(data = NE.States.Boundary.US, aes(color ="color"), 
+    geom_sf(data = NE.States.Boundary.US, aes(color ="color"),
             show.legend = "line") +
-    scale_color_manual(name = "", labels = "State Boundary", 
+    scale_color_manual(name = "", labels = "State Boundary",
                        values = c("color" = "gray18")) +
     geom_sf(data = point_HARV, aes(shape = "shape"), color = "purple") +
-    scale_shape_manual(name = "", labels = "Fisher Tower", 
+    scale_shape_manual(name = "", labels = "Fisher Tower",
                        values = c("shape" = 19)) +
     ggtitle("Fisher Tower location") +
     theme(legend.background = element_rect(color = NA)) +

--- a/episodes/10-vector-csv-to-shapefile-in-r.Rmd
+++ b/episodes/10-vector-csv-to-shapefile-in-r.Rmd
@@ -1,5 +1,5 @@
 ---
-title: Convert from .csv to a Shapefile
+title: Convert from .csv to a Vector Layer
 teaching: 40
 exercises: 20
 source: Rmd
@@ -19,7 +19,7 @@ source("setup.R")
 
 :::::::::::::::::::::::::::::::::::::::: questions
 
-- How can I import CSV files as shapefiles in R?
+- How can I import CSV files as vector layers in R?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -42,43 +42,42 @@ point_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HARVtower_UTM18N.shp"
 
 ## Things You'll Need To Complete This Episode
 
-See the [lesson homepage](.) for detailed information about the software, data, 
-and other prerequisites you will need to work through the examples in this 
+See the [lesson homepage](.) for detailed information about the software, data,
+and other prerequisites you will need to work through the examples in this
 episode.
 
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-This episode will review how to import spatial points stored in `.csv` (Comma 
-Separated Value) format into R as an `sf` spatial object. We will also 
-reproject data imported from a shapefile format, export this data as a 
-shapefile, and plot raster and vector data as layers in the same plot.
+This episode will review how to import spatial points stored in `.csv` (Comma
+Separated Value) format into R as an `sf` spatial object. We will also
+reproject data imported from an ESRI `shapefile` format, export the reprojected data as an ESRI `shapefile`, and plot raster and vector data as layers in the same plot.
 
 ## Spatial Data in Text Format
 
 The `HARV_PlotLocations.csv` file contains `x, y` (point) locations for study
 plot where NEON collects data on
-[vegetation and other ecological metrics](https://www.neonscience.org/data-collection/terrestrial-organismal-sampling).
+[vegetation and other ecological metics](https://www.neonscience.org/data-collection/terrestrial-organismal-sampling).
 We would like to:
 
 - Create a map of these plot locations.
-- Export the data in a `shapefile` format to share with our colleagues. This
-  shapefile can be imported into any GIS software.
+- Export the data in an ESRI `shapefile` format to share with our colleagues. This
+  `shapefile` can be imported into most GIS software.
 - Create a map showing vegetation height with plot locations layered on top.
 
 Spatial data are sometimes stored in a text file format (`.txt` or `.csv`). If
 the text file has an associated `x` and `y` location column, then we can
-convert it into an `sf` spatial object. The `sf` object allows us to store both 
-the `x,y` values that represent the coordinate location of each point and the 
-associated attribute data - or columns describing each feature in the spatial 
+convert it into an `sf` spatial object. The `sf` object allows us to store both
+the `x,y` values that represent the coordinate location of each point and the
+associated attribute data - or columns describing each feature in the spatial
 object.
 
 We will continue using the `sf` and `terra` packages in this episode.
 
 ## Import .csv
 
-To begin let's import a `.csv` file that contains plot coordinate `x, y` 
-locations at the NEON Harvard Forest Field Site (`HARV_PlotLocations.csv`) and 
+To begin let's import a `.csv` file that contains plot coordinate `x, y`
+locations at the NEON Harvard Forest Field Site (`HARV_PlotLocations.csv`) and
 look at the structure of that new object:
 
 ```{r read-csv}
@@ -88,10 +87,10 @@ plot_locations_HARV <-
 str(plot_locations_HARV)
 ```
 
-We now have a data frame that contains 21 locations (rows) and 16 variables 
-(attributes). Note that all of our character data was imported into R as 
-character (text) data. Next, let's explore the dataframe to determine whether 
-it contains columns with coordinate values. If we are lucky, our `.csv` will 
+We now have a data frame that contains 21 locations (rows) and 16 variables
+(attributes). Note that all of our character data was imported into R as
+character (text) data. Next, let's explore the dataframe to determine whether
+it contains columns with coordinate values. If we are lucky, our `.csv` will
 contain columns labeled:
 
 - "X" and "Y" OR
@@ -106,9 +105,9 @@ names(plot_locations_HARV)
 
 ## Identify X,Y Location Columns
 
-Our column names include several fields that might contain spatial information. 
-The `plot_locations_HARV$easting` and `plot_locations_HARV$northing` columns 
-contain coordinate values. We can confirm this by looking at the first six rows 
+Our column names include several fields that might contain spatial information.
+The `plot_locations_HARV$easting` and `plot_locations_HARV$northing` columns
+contain coordinate values. We can confirm this by looking at the first six rows
 of our data.
 
 ```{r check-out-coordinates}
@@ -116,8 +115,8 @@ head(plot_locations_HARV$easting)
 head(plot_locations_HARV$northing)
 ```
 
-We have coordinate values in our data frame. In order to convert our data frame 
-to an `sf` object, we also need to know the CRS associated with those 
+We have coordinate values in our data frame. In order to convert our data frame
+to an `sf` object, we also need to know the CRS associated with those
 coordinate values.
 
 There are several ways to figure out the CRS of spatial data in text format.
@@ -128,7 +127,7 @@ There are several ways to figure out the CRS of spatial data in text format.
   file header or somewhere in the data columns.
 
 Following the `easting` and `northing` columns, there is a `geodeticDa` and a
-`utmZone` column. These appear to contain CRS information (`datum` and 
+`utmZone` column. These appear to contain CRS information (`datum` and
 `projection`). Let's view those next.
 
 ```{r view-CRS-info}
@@ -149,26 +148,26 @@ we learned about the components of a `proj4` string. We have everything we need
 to assign a CRS to our data frame.
 
 To create the `proj4` associated with UTM Zone 18 WGS84 we can look up the
-projection on the 
-[Spatial Reference website](https://www.spatialreference.org/ref/epsg/wgs-84-utm-zone-18n/), 
-which contains a list of CRS formats for each projection. From here, we can 
-extract the 
+projection on the
+[Spatial Reference website](https://www.spatialreference.org/ref/epsg/wgs-84-utm-zone-18n/),
+which contains a list of CRS formats for each projection. From here, we can
+extract the
 [proj4 string for UTM Zone 18N WGS84](https://www.spatialreference.org/ref/epsg/wgs-84-utm-zone-18n/proj4/).
 
-However, if we have other data in the UTM Zone 18N projection, it's much easier 
-to use the `st_crs()` function to extract the CRS in `proj4` format from that 
-object and assign it to our new spatial object. We've seen this CRS before with 
+However, if we have other data in the UTM Zone 18N projection, it's much easier
+to use the `st_crs()` function to extract the CRS in `proj4` format from that
+object and assign it to our new spatial object. We've seen this CRS before with
 our Harvard Forest study site (`point_HARV`).
 
 ```{r explore-units}
 st_crs(point_HARV)
 ```
 
-The output above shows that the points shapefile is in UTM zone 18N. We can 
-thus use the CRS from that spatial object to convert our non-spatial dataframe 
+The output above shows that the points vector layer is in UTM zone 18N. We can
+thus use the CRS from that spatial object to convert our non-spatial dataframe
 into an `sf` object.
 
-Next, let's create a `crs` object that we can use to define the CRS of our `sf` 
+Next, let's create a `crs` object that we can use to define the CRS of our `sf`
 object when we create it.
 
 ```{r crs-object}
@@ -180,7 +179,7 @@ class(utm18nCRS)
 
 ## .csv to sf object
 
-Next, let's convert our dataframe into an `sf` object. To do this, we need to 
+Next, let's convert our dataframe into an `sf` object. To do this, we need to
 specify:
 
 1. The columns containing X (`easting`) and Y (`northing`) coordinate values
@@ -189,8 +188,8 @@ specify:
 We will use the `st_as_sf()` function to perform the conversion.
 
 ```{r convert-csv-shapefile}
-plot_locations_sp_HARV <- st_as_sf(plot_locations_HARV, 
-                                   coords = c("easting", "northing"), 
+plot_locations_sp_HARV <- st_as_sf(plot_locations_HARV,
+                                   coords = c("easting", "northing"),
                                    crs = utm18nCRS)
 ```
 
@@ -213,10 +212,10 @@ ggplot() +
 ## Plot Extent
 
 In
-[Open and Plot Shapefiles in R](06-vector-open-shapefile-in-r/)
+[Open and Plot Vector Layers in R](06-vector-open-shapefile-in-r/)
 we learned about spatial object extent. When we plot several spatial layers in
-R using `ggplot`, all of the layers of the plot are considered in setting the 
-boundaries of the plot. To show this, let's plot our `aoi_boundary_HARV` object 
+R using `ggplot`, all of the layers of the plot are considered in setting the
+boundaries of the plot. To show this, let's plot our `aoi_boundary_HARV` object
 with our vegetation plots.
 
 ```{r plot-data}
@@ -226,7 +225,7 @@ ggplot() +
   ggtitle("AOI Boundary Plot")
 ```
 
-When we plot the two layers together, `ggplot` sets the plot boundaries so that 
+When we plot the two layers together, `ggplot` sets the plot boundaries so that
 they are large enough to include all of the data included in all of the layers.
 That's really handy!
 
@@ -239,7 +238,7 @@ locations.
 
 Import the .csv: `HARV/HARV_2NewPhenPlots.csv` into R and do the following:
 
-1. Find the X and Y coordinate locations. Which value is X and which value is 
+1. Find the X and Y coordinate locations. Which value is X and which value is
    Y?
 2. These data were collected in a geographic coordinate system (WGS84). Convert
   the dataframe into an `sf` object.
@@ -252,7 +251,7 @@ If you have extra time, feel free to add roads and other layers to your map!
 
 ## Answers
 
-1) 
+1)
 First we will read in the new csv file and look at the data structure.
 
 ```{r}
@@ -261,9 +260,9 @@ newplot_locations_HARV <-
 str(newplot_locations_HARV)
 ```
 
-2) 
-The US boundary data we worked with previously is in a geographic WGS84 CRS. We 
-can use that data to establish a CRS for this data. First we will extract the 
+2)
+The US boundary data we worked with previously is in a geographic WGS84 CRS. We
+can use that data to establish a CRS for this data. First we will extract the
 CRS from the `country_boundary_US` object and confirm that it is WGS84.
 
 ```{r}
@@ -271,12 +270,12 @@ geogCRS <- st_crs(country_boundary_US)
 geogCRS
 ```
 
-Then we will convert our new data to a spatial dataframe, using the `geogCRS` 
+Then we will convert our new data to a spatial dataframe, using the `geogCRS`
 object as our CRS.
 
 ```{r}
-newPlot.Sp.HARV <- st_as_sf(newplot_locations_HARV, 
-                            coords = c("decimalLon", "decimalLat"), 
+newPlot.Sp.HARV <- st_as_sf(newplot_locations_HARV,
+                            coords = c("decimalLon", "decimalLat"),
                             crs = geogCRS)
 ```
 
@@ -286,8 +285,8 @@ Next we'll confirm that the CRS for our new object is correct.
 st_crs(newPlot.Sp.HARV)
 ```
 
-We will be adding these new data points to the plot we created before. The data 
-for the earlier plot was in UTM. Since we're using `ggplot`, it will reproject 
+We will be adding these new data points to the plot we created before. The data
+for the earlier plot was in UTM. Since we're using `ggplot`, it will reproject
 the data for us.
 
 3) Now we can create our plot.
@@ -303,18 +302,18 @@ ggplot() +
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-## Export a Shapefile
+## Export to an ESRI `shapefile`
 
-We can write an R spatial object to a shapefile using the `st_write` function
+We can write an R spatial object to an ESRI `shapefile` using the `st_write` function
 in `sf`. To do this we need the following arguments:
 
 - the name of the spatial object (`plot_locations_sp_HARV`)
-- the directory where we want to save our shapefile (to use `current = getwd()` 
+- the directory where we want to save our ESRI `shapefile` (to use `current = getwd()`
   or you can specify a different path)
-- the name of the new shapefile  (`PlotLocations_HARV`)
+- the name of the new ESRI `shapefile` (`PlotLocations_HARV`)
 - the driver which specifies the file format (ESRI Shapefile)
 
-We can now export the spatial object as a shapefile.
+We can now export the spatial object as an ESRI `shapefile`.
 
 ```{r write-shapefile, warnings="hide", eval=FALSE}
 st_write(plot_locations_sp_HARV,
@@ -325,7 +324,7 @@ st_write(plot_locations_sp_HARV,
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
-- Know the projection (if any) of your point data prior to converting to a 
+- Know the projection (if any) of your point data prior to converting to a
   spatial object.
 - Convert a data frame to an `sf` object using the `st_as_sf()` function.
 - Export an `sf` object as text using the `st_write()` function.

--- a/episodes/11-vector-raster-integration.Rmd
+++ b/episodes/11-vector-raster-integration.Rmd
@@ -18,7 +18,7 @@ source("setup.R")
 
 :::::::::::::::::::::::::::::::::::::::: questions
 
-- How can I crop raster objects to vector objects, and extract the summary of 
+- How can I crop raster objects to vector objects, and extract the summary of
   raster pixels?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -32,12 +32,11 @@ library(dplyr)
 
 ```{r load-data, echo=FALSE, results="hide"}
 # Learners will have this data loaded from earlier episodes
-# shapefiles
-point_HARV <- 
+point_HARV <-
   st_read("data/NEON-DS-Site-Layout-Files/HARV/HARVtower_UTM18N.shp")
-lines_HARV <- 
+lines_HARV <-
   st_read("data/NEON-DS-Site-Layout-Files/HARV/HARV_roads.shp")
-aoi_boundary_HARV <- 
+aoi_boundary_HARV <-
   st_read("data/NEON-DS-Site-Layout-Files/HARV/HarClip_UTMZ18.shp")
 
 # CHM
@@ -50,8 +49,8 @@ CHM_HARV_df <- as.data.frame(CHM_HARV, xy = TRUE)
 plot_locations_HARV <-
   read.csv("data/NEON-DS-Site-Layout-Files/HARV/HARV_PlotLocations.csv")
 utm18nCRS <- st_crs(point_HARV)
-plot_locations_sp_HARV <- st_as_sf(plot_locations_HARV, 
-                                   coords = c("easting", "northing"), 
+plot_locations_sp_HARV <- st_as_sf(plot_locations_HARV,
+                                   coords = c("easting", "northing"),
                                    crs = utm18nCRS)
 ```
 
@@ -59,22 +58,22 @@ plot_locations_sp_HARV <- st_as_sf(plot_locations_HARV,
 
 ## Things You'll Need To Complete This Episode
 
-See the [lesson homepage](.) for detailed information about the software, data, 
-and other prerequisites you will need to work through the examples in this 
+See the [lesson homepage](.) for detailed information about the software, data,
+and other prerequisites you will need to work through the examples in this
 episode.
 
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 This episode explains how to crop a raster using the extent of a vector
-shapefile. We will also cover how to extract values from a raster that occur
+layer. We will also cover how to extract values from a raster that occur
 within a set of polygons, or in a buffer (surrounding) region around a set of
 points.
 
 ## Crop a Raster to Vector Extent
 
 We often work with spatial layers that have different spatial extents. The
-spatial extent of a shapefile or R spatial object represents the geographic
+spatial extent of a vector layer or R spatial object represents the geographic
 "edge" or location that is the furthest north, south east and west. Thus it
 represents the overall geographic coverage of the spatial object.
 
@@ -91,17 +90,17 @@ we have worked with in this workshop:
 
 ```{r view-extents, echo=FALSE, results="hide"}
 # code not shown, for demonstration purposes only
-# create CHM as a shapefile
+# create CHM as a vector layer
 CHM_HARV_sp <- st_as_sf(CHM_HARV_df, coords = c("x", "y"), crs = utm18nCRS)
 # approximate the boundary box with a random sample of raster points
 CHM_rand_sample <- sample_n(CHM_HARV_sp, 10000)
 lines_HARV <- st_read("data/NEON-DS-Site-Layout-Files/HARV/HARV_roads.shp")
-plots_HARV <- 
+plots_HARV <-
   st_read("data/NEON-DS-Site-Layout-Files/HARV/PlotLocations_HARV.shp")
 ```
 
 ```{r compare-data-extents, echo=FALSE}
-# code not shown, for demonstration purposes only 
+# code not shown, for demonstration purposes only
 ggplot() +
   geom_sf(data = st_convex_hull(st_union(CHM_rand_sample)), fill = "green") +
   geom_sf(data = st_convex_hull(st_union(lines_HARV)),
@@ -111,16 +110,16 @@ ggplot() +
   geom_sf(data = st_convex_hull(st_union(plot_locations_sp_HARV)),
           fill = "black", alpha = 0.4) +
   geom_sf(data = plots_HARV, color = "white") +
-  theme(legend.position = "none") + 
+  theme(legend.position = "none") +
   coord_sf()
 
 ```
 
 Frequent use cases of cropping a raster file include reducing file size and
 creating maps. Sometimes we have a raster file that is much larger than our
-study area or area of interest. It is often more efficient to crop the raster 
-to the extent of our study area to reduce file sizes as we process our data. 
-Cropping a raster can also be useful when creating pretty maps so that the 
+study area or area of interest. It is often more efficient to crop the raster
+to the extent of our study area to reduce file sizes as we process our data.
+Cropping a raster can also be useful when creating pretty maps so that the
 raster layer matches the extent of the desired vector layers.
 
 ## Crop a Raster Using Vector Extent
@@ -130,14 +129,14 @@ spatial object. To do this, we need to specify the raster to be cropped and the
 spatial object that will be used to crop the raster. R will use the `extent` of
 the spatial object as the cropping boundary.
 
-To illustrate this, we will crop the Canopy Height Model (CHM) to only include 
-the area of interest (AOI). Let's start by plotting the full extent of the CHM 
-data and overlay where the AOI falls within it. The boundaries of the AOI will 
+To illustrate this, we will crop the Canopy Height Model (CHM) to only include
+the area of interest (AOI). Let's start by plotting the full extent of the CHM
+data and overlay where the AOI falls within it. The boundaries of the AOI will
 be colored blue, and we use `fill = NA` to make the area transparent.
 
 ```{r crop-by-vector-extent}
 ggplot() +
-  geom_raster(data = CHM_HARV_df, aes(x = x, y = y, fill = HARV_chmCrop)) + 
+  geom_raster(data = CHM_HARV_df, aes(x = x, y = y, fill = HARV_chmCrop)) +
   scale_fill_gradientn(name = "Canopy Height", colors = terrain.colors(10)) +
   geom_sf(data = aoi_boundary_HARV, color = "blue", fill = NA) +
   coord_sf()
@@ -152,11 +151,11 @@ that falls within the boundaries of the AOI.
 CHM_HARV_Cropped <- crop(x = CHM_HARV, y = aoi_boundary_HARV)
 ```
 
-Now we can plot the cropped CHM data, along with a boundary box showing the 
-full CHM extent. However, remember, since this is raster data, we need to 
-convert to a data frame in order to plot using `ggplot`. To get the boundary 
-box from CHM, the `st_bbox()` will extract the 4 corners of the rectangle that 
-encompass all the features contained in this object. The `st_as_sfc()` converts 
+Now we can plot the cropped CHM data, along with a boundary box showing the
+full CHM extent. However, remember, since this is raster data, we need to
+convert to a data frame in order to plot using `ggplot`. To get the boundary
+box from CHM, the `st_bbox()` will extract the 4 corners of the rectangle that
+encompass all the features contained in this object. The `st_as_sfc()` converts
 these 4 coordinates into a polygon that we can plot:
 
 ```{r show-cropped-area}
@@ -164,10 +163,10 @@ CHM_HARV_Cropped_df <- as.data.frame(CHM_HARV_Cropped, xy = TRUE)
 
 ggplot() +
   geom_sf(data = st_as_sfc(st_bbox(CHM_HARV)), fill = "green",
-          color = "green", alpha = .2) +  
+          color = "green", alpha = .2) +
   geom_raster(data = CHM_HARV_Cropped_df,
-              aes(x = x, y = y, fill = HARV_chmCrop)) + 
-  scale_fill_gradientn(name = "Canopy Height", colors = terrain.colors(10)) + 
+              aes(x = x, y = y, fill = HARV_chmCrop)) +
+  scale_fill_gradientn(name = "Canopy Height", colors = terrain.colors(10)) +
   coord_sf()
 ```
 
@@ -179,9 +178,9 @@ below).
 ```{r view-crop-extent}
 ggplot() +
   geom_raster(data = CHM_HARV_Cropped_df,
-              aes(x = x, y = y, fill = HARV_chmCrop)) + 
-  geom_sf(data = aoi_boundary_HARV, color = "blue", fill = NA) + 
-  scale_fill_gradientn(name = "Canopy Height", colors = terrain.colors(10)) + 
+              aes(x = x, y = y, fill = HARV_chmCrop)) +
+  geom_sf(data = aoi_boundary_HARV, color = "blue", fill = NA) +
+  scale_fill_gradientn(name = "Canopy Height", colors = terrain.colors(10)) +
   coord_sf()
 ```
 
@@ -194,8 +193,8 @@ st_bbox(aoi_boundary_HARV)
 st_bbox(plot_locations_sp_HARV)
 ```
 
-Our plot location extent is not the largest but is larger than the AOI 
-Boundary. It would be nice to see our vegetation plot locations plotted on top 
+Our plot location extent is not the largest but is larger than the AOI
+Boundary. It would be nice to see our vegetation plot locations plotted on top
 of the Canopy Height Model information.
 
 :::::::::::::::::::::::::::::::::::::::  challenge
@@ -215,11 +214,11 @@ CHM_plots_HARVcrop <- crop(x = CHM_HARV, y = plot_locations_sp_HARV)
 
 CHM_plots_HARVcrop_df <- as.data.frame(CHM_plots_HARVcrop, xy = TRUE)
 
-ggplot() + 
-  geom_raster(data = CHM_plots_HARVcrop_df, 
-              aes(x = x, y = y, fill = HARV_chmCrop)) + 
-  scale_fill_gradientn(name = "Canopy Height", colors = terrain.colors(10)) + 
-  geom_sf(data = plot_locations_sp_HARV) + 
+ggplot() +
+  geom_raster(data = CHM_plots_HARVcrop_df,
+              aes(x = x, y = y, fill = HARV_chmCrop)) +
+  scale_fill_gradientn(name = "Canopy Height", colors = terrain.colors(10)) +
+  geom_sf(data = plot_locations_sp_HARV) +
   coord_sf()
 ```
 
@@ -228,21 +227,21 @@ ggplot() +
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 In the plot above, created in the challenge, all the vegetation plot locations
-(black dots) appear on the Canopy Height Model raster layer except for one. One 
+(black dots) appear on the Canopy Height Model raster layer except for one. One
 is situated on the blank space to the left of the map. Why?
 
 A modification of the first figure in this episode is below, showing the
 relative extents of all the spatial objects. Notice that the extent for our
 vegetation plot layer (black) extends further west than the extent of our CHM
-raster (bright green). The `crop()` function will make a raster extent smaller, 
-it will not expand the extent in areas where there are no data. Thus, the 
-extent of our vegetation plot layer will still extend further west than the 
+raster (bright green). The `crop()` function will make a raster extent smaller,
+it will not expand the extent in areas where there are no data. Thus, the
+extent of our vegetation plot layer will still extend further west than the
 extent of our (cropped) raster data (dark green).
 
 ```{r, echo=FALSE}
 # code not shown, demonstration only
-# create CHM_plots_HARVcrop as a shape file
-CHM_plots_HARVcrop_sp <- st_as_sf(CHM_plots_HARVcrop_df, coords = c("x", "y"), 
+# create CHM_plots_HARVcrop as a vector layer
+CHM_plots_HARVcrop_sp <- st_as_sf(CHM_plots_HARVcrop_df, coords = c("x", "y"),
                                   crs = utm18nCRS)
 # approximate the boundary box with random sample of raster points
 CHM_plots_HARVcrop_sp_rand_sample = sample_n(CHM_plots_HARVcrop_sp, 10000)
@@ -253,7 +252,7 @@ CHM_plots_HARVcrop_sp_rand_sample = sample_n(CHM_plots_HARVcrop_sp, 10000)
 
 ## Define an Extent
 
-So far, we have used a shapefile to crop the extent of a raster dataset.
+So far, we have used a vector layer to crop the extent of a raster dataset.
 Alternatively, we can also the `ext()` function to define an extent to be
 used as a cropping boundary. This creates a new object of class extent. Here we
 will provide the `ext()` function our xmin, xmax, ymin, and ymax (in that
@@ -288,23 +287,23 @@ To plot this data using `ggplot()` we need to convert it to a dataframe.
 CHM_HARV_manual_cropped_df <- as.data.frame(CHM_HARV_manual_cropped, xy = TRUE)
 ```
 
-Now we can plot this cropped data. We will show the AOI boundary on the same 
+Now we can plot this cropped data. We will show the AOI boundary on the same
 plot for scale.
 
 ```{r show-manual-crop-area}
-ggplot() + 
+ggplot() +
   geom_sf(data = aoi_boundary_HARV, color = "blue", fill = NA) +
   geom_raster(data = CHM_HARV_manual_cropped_df,
-              aes(x = x, y = y, fill = HARV_chmCrop)) + 
-  scale_fill_gradientn(name = "Canopy Height", colors = terrain.colors(10)) + 
+              aes(x = x, y = y, fill = HARV_chmCrop)) +
+  scale_fill_gradientn(name = "Canopy Height", colors = terrain.colors(10)) +
   coord_sf()
 ```
 
 ## Extract Raster Pixels Values Using Vector Polygons
 
 Often we want to extract values from a raster layer for particular locations -
-for example, plot locations that we are sampling on the ground. We can extract 
-all pixel values within 20m of our x,y point of interest. These can then be 
+for example, plot locations that we are sampling on the ground. We can extract
+all pixel values within 20m of our x,y point of interest. These can then be
 summarized into some value of interest (e.g. mean, maximum, total).
 
 ![](fig//BufferSquare.png){alt='Image shows raster information extraction using 20m polygon boundary.'}
@@ -316,11 +315,11 @@ requires:
 - The raster that we wish to extract values from,
 - The vector layer containing the polygons that we wish to use as a boundary or
   boundaries,
-- we can tell it to store the output values in a data frame using 
+- we can tell it to store the output values in a data frame using
   `raw = FALSE` (this is optional).
 
 We will begin by extracting all canopy height pixel values located within our
-`aoi_boundary_HARV` polygon which surrounds the tower located at the NEON 
+`aoi_boundary_HARV` polygon which surrounds the tower located at the NEON
 Harvard Forest field site.
 
 ```{r extract-from-raster}
@@ -329,26 +328,26 @@ tree_height <- extract(x = CHM_HARV, y = aoi_boundary_HARV, raw = FALSE)
 str(tree_height)
 ```
 
-When we use the `extract()` function, R extracts the value for each pixel 
-located within the boundary of the polygon being used to perform the extraction 
+When we use the `extract()` function, R extracts the value for each pixel
+located within the boundary of the polygon being used to perform the extraction
 - in this case the `aoi_boundary_HARV` object (a single polygon). Here, the
 function extracted values from 18,450 pixels.
 
 We can create a histogram of tree height values within the boundary to better
 understand the structure or height distribution of trees at our site. We will
-use the column `HARV_chmCrop` from our data frame as our x values, as this 
+use the column `HARV_chmCrop` from our data frame as our x values, as this
 column represents the tree heights for each pixel.
 
 ```{r view-extract-histogram}
-ggplot() + 
+ggplot() +
   geom_histogram(data = tree_height, aes(x = HARV_chmCrop)) +
   ggtitle("Histogram of CHM Height Values (m)") +
-  xlab("Tree Height") + 
+  xlab("Tree Height") +
   ylab("Frequency of Pixels")
 ```
 
-We can also use the `summary()` function to view descriptive statistics 
-including min, max, and mean height values. These values help us better 
+We can also use the `summary()` function to view descriptive statistics
+including min, max, and mean height values. These values help us better
 understand vegetation at our field site.
 
 ```{r}
@@ -358,11 +357,11 @@ summary(tree_height$HARV_chmCrop)
 ## Summarize Extracted Raster Values
 
 We often want to extract summary values from a raster. We can tell R the type
-of summary statistic we are interested in using the `fun =` argument. Let's 
-extract a mean height value for our AOI. 
+of summary statistic we are interested in using the `fun =` argument. Let's
+extract a mean height value for our AOI.
 
 ```{r summarize-extract}
-mean_tree_height_AOI <- extract(x = CHM_HARV, y = aoi_boundary_HARV, 
+mean_tree_height_AOI <- extract(x = CHM_HARV, y = aoi_boundary_HARV,
                                 fun = mean)
 
 mean_tree_height_AOI
@@ -374,17 +373,17 @@ canopy height model is 22.43 meters.
 ## Extract Data using x,y Locations
 
 We can also extract pixel values from a raster by defining a buffer or area
-surrounding individual point locations using the `st_buffer()` function. To do 
-this we define the summary argument (`fun = mean`) and the buffer distance 
-(`dist = 20`) which represents the radius of a circular region around each 
-point. By default, the units of the buffer are the same units as the data's 
-CRS. All pixels that are touched by the buffer region are included in the 
+surrounding individual point locations using the `st_buffer()` function. To do
+this we define the summary argument (`fun = mean`) and the buffer distance
+(`dist = 20`) which represents the radius of a circular region around each
+point. By default, the units of the buffer are the same units as the data's
+CRS. All pixels that are touched by the buffer region are included in the
 extract.
 
 ![](fig/BufferCircular.png){alt='Image shows raster information extraction using 20m buffer region.'}
 Image Source: National Ecological Observatory Network (NEON)
 
-Let's put this into practice by figuring out the mean tree height in the 20m 
+Let's put this into practice by figuring out the mean tree height in the 20m
 around the tower location (`point_HARV`).
 
 ```{r extract-point-to-buffer}
@@ -399,9 +398,9 @@ mean_tree_height_tower
 
 ## Challenge: Extract Raster Height Values For Plot Locations
 
-1) Use the plot locations object (`plot_locations_sp_HARV`) to extract an 
-  average tree height for the area within 20m of each vegetation plot location 
-  in the study area. Because there are multiple plot locations, there will be 
+1) Use the plot locations object (`plot_locations_sp_HARV`) to extract an
+  average tree height for the area within 20m of each vegetation plot location
+  in the study area. Because there are multiple plot locations, there will be
   multiple averages returned.
 
 2) Create a plot showing the mean tree height of each area.
@@ -413,7 +412,7 @@ mean_tree_height_tower
 ```{r hist-tree-height-veg-plot}
 # extract data at each plot location
 mean_tree_height_plots_HARV <- extract(x = CHM_HARV,
-                                       y = st_buffer(plot_locations_sp_HARV, 
+                                       y = st_buffer(plot_locations_sp_HARV,
                                                      dist = 20),
                                        fun = mean)
 
@@ -421,10 +420,10 @@ mean_tree_height_plots_HARV <- extract(x = CHM_HARV,
 mean_tree_height_plots_HARV
 
 # plot data
-ggplot(data = mean_tree_height_plots_HARV, aes(ID, HARV_chmCrop)) + 
-  geom_col() + 
-  ggtitle("Mean Tree Height at each Plot") + 
-  xlab("Plot ID") + 
+ggplot(data = mean_tree_height_plots_HARV, aes(ID, HARV_chmCrop)) +
+  geom_col() +
+  ggtitle("Mean Tree Height at each Plot") +
+  xlab("Plot ID") +
   ylab("Tree Height (m)")
 ```
 
@@ -437,7 +436,7 @@ ggplot(data = mean_tree_height_plots_HARV, aes(ID, HARV_chmCrop)) +
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
 - Use the `crop()` function to crop a raster object.
-- Use the `extract()` function to extract pixels from a raster object that fall 
+- Use the `extract()` function to extract pixels from a raster object that fall
   within a particular extent boundary.
 - Use the `ext()` function to define an extent.
 


### PR DESCRIPTION
Edits are part of Issue #312 to update the terms “shapefile” and “simple features”

1. Replaced the term “shapefile” with "vector layer" where appropriate.

- Sometimes this was not a simple replacement as it needed to be made clear when ESRI shapefiles were the format of the vector layers, or when the term shapefile was being used as shorthand for a vector layer in R.
- It was not always possible to remove all references to shapefiles as sometimes the shapefile file format needed to be referenced – in those cases I explicitly called it an ESRI ‘Shapefile’ as it is a propriety format. Also, this is also the driver in the code mentions ESRI.

2. - It is sometimes unclear when we are referring to a “vector layer” or a “spatial object” in R. I have tried to make it clear and match with what was already in the lesson.

3. In “10-vector-csv-to-shapefile-in-r.Rmd”, replaced "all" with "most" for "This ESRI shapefile can be imported into _MOST_ GIS software."

4. When the contents of that layer are being referred to, I have replaced “simple features” with “spatial features”

5. Several of the filenames reference the term shapefile, but I have not updated any of these, just the ‘plain text’ names
