### PR TITLE
Typo in episode 3 Reproject and Plot Digital Terrain challenge

### DIFF
--- a/episodes/03-raster-reproject-in-r.Rmd
+++ b/episodes/03-raster-reproject-in-r.Rmd
@@ -318,14 +318,14 @@ DSM_hill_SJER_WGS <-
     rast("data/NEON-DS-Airborne-Remote-Sensing/SJER/DSM/SJER_DSMhill_WGS84.tif")
 
 # reproject raster
-DTM_hill_UTMZ18N_SJER <- project(DSM_hill_SJER_WGS,
+DSM_hill_UTMZ18N_SJER <- project(DSM_hill_SJER_WGS,
                                  crs(DSM_SJER),
                                  res = 1)
 
 # convert to data.frames
 DSM_SJER_df <- as.data.frame(DSM_SJER, xy = TRUE)
 
-DSM_hill_SJER_df <- as.data.frame(DTM_hill_UTMZ18N_SJER, xy = TRUE)
+DSM_hill_SJER_df <- as.data.frame(DSM_hill_UTMZ18N_SJER, xy = TRUE)
 
 ggplot() +
      geom_raster(data = DSM_hill_SJER_df, 


### PR DESCRIPTION
on lines 321 and 328, original challenge says DTM_hill_SJER, 

but it should be DSM_hill_UTMZ18N_SJER (321) and DSM_hill_SJER_df(328) 

https://datacarpentry.org/r-raster-vector-geospatial/03-raster-reproject-in-r.html#challenge-reproject-then-plot-a-digital-terrain-model

