### PR TITLE
Ep 9: Overlay error in episode between state and country boundary

### DIFF
--- a/episodes/09-vector-when-data-dont-line-up-crs.Rmd
+++ b/episodes/09-vector-when-data-dont-line-up-crs.Rmd
@@ -141,8 +141,8 @@ boundaries and country boundaries.
 
 ```{r us-boundaries-thickness}
 ggplot() +
-  geom_sf(data = country_boundary_US, color = "gray18", size = 2) +
-  geom_sf(data = state_boundary_US, color = "gray40") +
+  geom_sf(data = state_boundary_US, color = "gray60") +
+  geom_sf(data = country_boundary_US, color = "black",alpha = 0.25,size = 5)
   ggtitle("Map of Contiguous US State Boundaries") +
   coord_sf()
 ```

--- a/episodes/09-vector-when-data-dont-line-up-crs.Rmd
+++ b/episodes/09-vector-when-data-dont-line-up-crs.Rmd
@@ -251,8 +251,8 @@ conversion:
 
 ```{r layer-point-on-states}
 ggplot() +
-  geom_sf(data = country_boundary_US, size = 2, color = "gray18") +
-  geom_sf(data = state_boundary_US, color = "gray40") +
+  geom_sf(data = state_boundary_US, color = "gray60") +
+  geom_sf(data = country_boundary_US, size = 5, alpha = 0.25, color = "black") +
   geom_sf(data = point_HARV, shape = 19, color = "purple") +
   ggtitle("Map of Contiguous US State Boundaries") +
   coord_sf()


### PR DESCRIPTION

When combining the state and country boundary, the lesson states the county boundary is supposed to be a slightly bolded outline, however, the state boundary shapefile is masking the country boundary so the bold outline does not show up. This would work if the country boundary layer had an alpha and was layered over the state boundary layer.
![09-vector-when-data-dont-line-up-crs-rendered-find-coordinates-1](https://github.com/datacarpentry/r-raster-vector-geospatial/assets/48770663/9b693136-a6de-4cc6-a1aa-3dc1586a3be8)

After making country border darker, adding alpha, and increasing size slightly: 

![ep 9 boundary overlay fix](https://github.com/datacarpentry/r-raster-vector-geospatial/assets/48770663/a09c5636-305c-4996-addd-121ca1341caf)

(Here's what it looks like in our fork:https://ucsb-dreamlab.github.io/r-raster-vector-geospatial/09-vector-when-data-dont-line-up-crs.html) 
