### PR TITLE
Fix links to setup instructions

### DIFF
--- a/index.md
+++ b/index.md
@@ -49,13 +49,13 @@ lesson.
 
 For installation instructions and to download the data used in this
 lesson, see the
-[Geospatial Workshop Overview](http://www.datacarpentry.org/geospatial-workshop/setup.html).
+[Geospatial Workshop Overview](http://www.datacarpentry.org/geospatial-workshop/#setup).
 
 ### Setup RStudio Project
 
 Make sure you have set up a RStudio project for this lesson, as
 described in the
-<a href="{{ site.baseurl }}/setup.html" target="_blank">setup instructions</a>
+[setup instructions](http://www.datacarpentry.org/geospatial-workshop/#setup)
 and that your working directory is correctly set.
 
 


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._

n/a

_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

[The Geospatial Workshop overview site](http://www.datacarpentry.org/geospatial-workshop/) has recently been migrated to the new lesson infrastructure, which has changed the location of the setup instructions. This PR updates the relevant links within the lesson.

_If any relevant discussions have taken place elsewhere, please provide links to these._

https://github.com/carpentries/lesson-transition/issues/27
