### PR TITLE
Update 09-vector-when-data-dont-line-up-crs.Rmd

### DIFF
--- a/episodes/09-vector-when-data-dont-line-up-crs.Rmd
+++ b/episodes/09-vector-when-data-dont-line-up-crs.Rmd
@@ -142,7 +142,7 @@ boundaries and country boundaries.
 ```{r us-boundaries-thickness}
 ggplot() +
   geom_sf(data = state_boundary_US, color = "gray60") +
-  geom_sf(data = country_boundary_US, color = "black",alpha = 0.25,size = 5)
+  geom_sf(data = country_boundary_US, color = "black",alpha = 0.25,size = 5) +
   ggtitle("Map of Contiguous US State Boundaries") +
   coord_sf()
 ```
@@ -155,7 +155,7 @@ First let's look at the CRS of our tower location object:
 st_crs(point_HARV)$proj4string
 ```
 
-Our project string for `DSM_HARV` specifies the UTM projection as follows:
+Our project string for `point_HARV` specifies the UTM projection as follows:
 
 `+proj=utm +zone=18 +datum=WGS84 +units=m +no_defs`
 
@@ -185,8 +185,7 @@ the lat/long projection as follows:
   coordinate system
 - **datum=WGS84:** the datum WGS84 (the datum refers to the  0,0 reference for
   the coordinate system used in the projection)
-- **ellps=WGS84:** the ellipsoid (how the earth's roundness is calculated)
-  is WGS84
+- **no_defs:** ensures that no defaults are used, but this is now obsolete
 
 Note that there are no specified units above. This is because this geographic
 coordinate reference system is in latitude and longitude which is most often


### PR DESCRIPTION
Adds a missing `+` to a broken ggplot2 chain and edits the description of `st_crs(state_boundary_US)$proj4string` to match the output.

<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
