### PR TITLE
Replace now superseded `gather()` with `pivot_longer()`

### DIFF
--- a/episodes/12-time-series-raster.Rmd
+++ b/episodes/12-time-series-raster.Rmd
@@ -187,13 +187,13 @@ xres(NDVI_HARV_stack)
 Once we have created our RasterStack, we can visualize our data. We can use the 
 `ggplot()` command to create a multi-panelled plot showing each band in our 
 RasterStack. First we need to create a data frame object. Because there are 
-multiple columns in our data that are not variables, we will tidy (or "gather") 
+multiple columns in our data that are not variables, we will tidy (or "pivot") 
 the data so that we have a single column with the NDVI observations. We will 
-use the function `gather()` from the `tidyr` package to do this:
+use the function `pivot_longer()` from the `tidyr` package to do this:
 
 ```{r plot-time-series}
 NDVI_HARV_stack_df <- as.data.frame(NDVI_HARV_stack, xy = TRUE) %>%
-    gather(variable, value, -(x:y))
+    pivot_longer(-(x:y), names_to = "variable", values_to = "value")
 ```
 
 Now we can plot our data using `ggplot()`. We want to create a separate panel 
@@ -228,7 +228,7 @@ we used above.
 
 ```{r ndvi-stack-wrap}
 NDVI_HARV_stack_df <- as.data.frame(NDVI_HARV_stack, xy = TRUE) %>%
-    gather(variable, value, -(x:y))
+    pivot_longer(-(x:y), names_to = "variable", values_to = "value")
 
 ggplot() +
   geom_raster(data = NDVI_HARV_stack_df , aes(x = x, y = y, fill = value)) +


### PR DESCRIPTION
Replaces `gather()` with `pivot_longer()`.  `gather()` still works, but it is superseded, so better to teach `pivot_longer()` I think.

<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
