### PR TITLE
Rm group by func call

### DIFF
--- a/episodes/02-raster-plot.Rmd
+++ b/episodes/02-raster-plot.Rmd
@@ -90,8 +90,7 @@ and `count()` functions:
 
 ```{r breaks-count}
 DSM_HARV_df %>%
-        group_by(fct_elevation) %>%
-        count()
+        count(fct_elevation)
 ```
 
 We might prefer to customize the cutoff values for these groups.
@@ -133,8 +132,7 @@ And we can get the count of values in each group in the same way we did before:
 
 ```{r break-count-custom}
 DSM_HARV_df %>%
-  group_by(fct_elevation_2) %>%
-  count()
+  count(fct_elevation_2)
 ```
 
 We can use those groups to plot our raster data, with each group being a 

--- a/episodes/02-raster-plot.Rmd
+++ b/episodes/02-raster-plot.Rmd
@@ -85,8 +85,7 @@ values of `fct_elevation`:
 unique(DSM_HARV_df$fct_elevation)
 ```
 
-And we can get the count of values in each group using `dplyr`'s `group_by()` 
-and `count()` functions:
+And we can get the count of values in each group using `dplyr`'s `count()` function:
 
 ```{r breaks-count}
 DSM_HARV_df %>%


### PR DESCRIPTION
The count() function is an alias for groupby +summarize(n()).  It will group by the variable and count it in one function call so including the groupby function is redundant.