### PR TITLE
revise typo in introduction of nlyr function - 01-raster-structure.Rmd

### DIFF
--- a/episodes/01-raster-structure.Rmd
+++ b/episodes/01-raster-structure.Rmd
@@ -318,7 +318,7 @@ raster: surface elevation in meters for one time period.
 
 A raster dataset can contain one or more bands. We can use the `rast()`
 function to import one single band from a single or multi-band raster. We can
-view the number of bands in a raster using the `nly()` function.
+view the number of bands in a raster using the `nlyr()` function.
 
 ```{r view-raster-bands}
 nlyr(DSM_HARV)


### PR DESCRIPTION
Function is `nlyr()` but was described as `nly` in the sentence preceding the code block.

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._


_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
