### PR TITLE
Update 07-vector-shapefile-attributes-in-r.Rmd

### DIFF
--- a/episodes/07-vector-shapefile-attributes-in-r.Rmd
+++ b/episodes/07-vector-shapefile-attributes-in-r.Rmd
@@ -341,7 +341,7 @@ We can use those line widths when we plot the data.
 
 ```{r harv-paths-map-wide, fig.cap="Roads and trails in the area demonstrating how to use different line thickness and colors."}
 ggplot() +
-  geom_sf(data = lines_HARV, aes(color = TYPE, size = TYPE)) +
+  geom_sf(data = lines_HARV, aes(color = TYPE, linewidth = TYPE)) +
   scale_color_manual(values = road_colors) +
   labs(color = 'Road Type') +
   scale_size_manual(values = line_widths) +


### PR DESCRIPTION
_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

In the line width example, the `size` aesthetic doesn't work (i.e., the lines are all the same size). We updated to `linewidth` as a proposed solution. However, we get the following warning (which also appears when using `size`), so this may not be the best fix: "Warning message: Using linewidth for a discrete variable is not advised."