### PR TITLE
Update 07-vector-shapefile-attributes-in-r.Rmd

### DIFF
--- a/episodes/07-vector-shapefile-attributes-in-r.Rmd
+++ b/episodes/07-vector-shapefile-attributes-in-r.Rmd
@@ -439,7 +439,7 @@ ggplot() +
   scale_color_manual(values = road_colors) +
   labs(color = 'Road Type') +
   theme(legend.text = element_text(size = 20),
-        legend.box.background = element_rect(size = 1)) +
+        legend.box.background = element_rect(linewidth = 1)) +
   ggtitle("NEON Harvard Forest Field Site",
           subtitle = "Roads & Trails - Modified Legend") +
   coord_sf()


### PR DESCRIPTION
_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

Update `element_rect(size = 1)` to `element_rect(line_width = 1)` to address warning: The `size` argument of `element_rect()` is deprecated as of ggplot2 3.4.0. ℹ Please use the `linewidth` argument instead.