### PR TITLE
Revert "uses consistent carpentries terminology"

### DIFF
--- a/episodes/05-raster-multi-band-in-r.Rmd
+++ b/episodes/05-raster-multi-band-in-r.Rmd
@@ -41,7 +41,7 @@ episode.
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 We introduced multi-band raster data in
-[an earlier episode](https://datacarpentry.org/organization-geospatial/01-intro-raster-data). 
+[an earlier lesson](https://datacarpentry.org/organization-geospatial/01-intro-raster-data). 
 This episode explores how to import and plot a multi-band raster in R.
 
 ## Getting Started with Multi-Band Data in R


### PR DESCRIPTION
Reverts datacarpentry/r-raster-vector-geospatial#475

That was a change in episode 5 and the lesson build failed.
There was a note about a checkmd file also changing. 

I don't see why the 1 word change could prevent the repo from building.