### PR TITLE
Fix plotRGB errors in Ep. 5

### DIFF
--- a/episodes/05-raster-multi-band-in-r.Rmd
+++ b/episodes/05-raster-multi-band-in-r.Rmd
@@ -268,14 +268,12 @@ range of potential values to increase the visual contrast of the image.
 ```{r plot-rbg-image-linear}
 plotRGB(RGB_stack_HARV,
         r = 1, g = 2, b = 3,
-        scale = 800,
         stretch = "lin")
 ```
 
 ```{r plot-rgb-image-hist}
 plotRGB(RGB_stack_HARV,
         r = 1, g = 2, b = 3,
-        scale = 800,
         stretch = "hist")
 ```
 


### PR DESCRIPTION
Remove `scale` argument from `plotRGB()` calls, as this argument currently is misleading (should not be larger than max value of bands within the raster).

Closes #476 
